### PR TITLE
fix(security): bind Brewfile trust to exact bytes and harden release and CI checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-<!-- Keep the PR description to a concise summary. Do not add generated footers,
-test-plan sections, or tool-attribution sections. -->
+<!-- Keep the PR description to a concise summary; do not add a test-plan section.
+If AI assisted, make the final body line exactly:
+AI disclosure: <model> with <how the output was verified>.
+Otherwise omit it. -->
 
 Summary:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,9 +158,9 @@ jobs:
     environment:
       name: ${{ matrix.environment }}
       deployment: false
-    # Cap at 45m: lint/commits finish in seconds, CodeQL runs ~20m, sanitizer
-    # test jobs ~10m. Anything past this is a hang — fail fast instead of
-    # burning up to 6h of the default runner budget.
+    # Cap matrix legs at 45m; sanitizer tests normally finish in about 10m and
+    # the other legs are quicker. Anything past this is a hang — fail fast
+    # instead of burning up to 6h of the default runner budget.
     timeout-minutes: 45
     permissions:
       contents: read
@@ -411,7 +411,7 @@ jobs:
     with:
       languages: '["swift"]'
       runner: "macos-26"
-      timeout-minutes: 30
+      timeout-minutes: 45
       build-mode: "manual"
       build-profile: "brewy-xcode"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
             add_check '{"name":"Lint","check":"lint","runner":"macos-26"}'
             add_check '{"name":"Periphery","check":"periphery","runner":"macos-26"}'
             add_check '{"name":"Build Brew JSON Probe","check":"probe-build","runner":"macos-26"}'
-            add_check '{"name":"Test (Thread Sanitizer)","check":"test-tsan","runner":"macos-26","xcodebuild_flags":"-enableCodeCoverage YES -enableThreadSanitizer YES","result_bundle":"TestResults-TSAN","environment":"codecov"}'
+            add_check '{"name":"Test (Thread Sanitizer)","check":"test-tsan","runner":"macos-26","xcodebuild_flags":"-only-testing:BrewyTests -enableCodeCoverage YES -enableThreadSanitizer YES","result_bundle":"TestResults-TSAN","environment":"codecov"}'
+            add_check '{"name":"Test (signed UI runner)","check":"test-ui","runner":"macos-26","xcodebuild_flags":"-only-testing:BrewyUITests","result_bundle":"TestResults-UI"}'
+            add_check '{"name":"Release helper validation","check":"release-helpers","runner":"ubuntu-slim"}'
             {
               echo "matrix=${MATRIX}"
               echo "run_codeql=false"
@@ -73,30 +75,48 @@ jobs:
           # certify every relevant leg for the current commit. Collapsing to a
           # commits-only matrix on `edited` lets a green run overwrite a prior failing
           # one on the same SHA, bypassing tests, lint, CodeQL and the rest.
-          CHANGED=$(git diff --name-only "${BASE_SHA}...HEAD")
-
-          NEEDS_LINT=0
-          NEEDS_TESTS=0
-          RUN_CODEQL=false
-          RUN_ZIZMOR=false
-
-          # Swift or CI workflow changes: lint + sanitizer tests
-          if grep -qE '\.swift$|^Brewy\.xcodeproj/|^\.swiftlint\.yml$|^\.github/workflows/ci\.yml$' <<< "${CHANGED}"; then
+          # Routing policy is a merge control, so never source its implementation
+          # from the untrusted PR checkout. During the helper's first introduction,
+          # fail closed to every route until a trusted base revision exists.
+          ROUTER_FILE="${RUNNER_TEMP}/brewy-ci-path-routing.sh"
+          if git show "${BASE_SHA}:scripts/ci-path-routing.sh" > "${ROUTER_FILE}"; then
+            # shellcheck source=scripts/ci-path-routing.sh
+            source "${ROUTER_FILE}"
+            reset_ci_routes
+            HAS_TRUSTED_ROUTER=true
+          else
             NEEDS_LINT=1
             NEEDS_TESTS=1
+            NEEDS_PROBE=1
+            NEEDS_PERIPHERY=1
+            NEEDS_RELEASE_HELPERS=1
+            RUN_CODEQL=true
+            RUN_ZIZMOR=true
+            HAS_TRUSTED_ROUTER=false
           fi
 
-          # Docs, typo config, or release workflow changes: lint/typos
-          if grep -qE '\.md$|^_typos\.toml$|^\.github/workflows/release\.yml$' <<< "${CHANGED}"; then
-            NEEDS_LINT=1
-          fi
+          # Consume raw NUL-delimited names. Human-oriented git output C-quotes
+          # control characters, which can otherwise bypass anchored path routes.
+          # Materialize first so `set -e` observes a failed diff producer; Bash does
+          # not propagate process-substitution failures through a successful loop.
+          CHANGED_PATHS_FILE="${RUNNER_TEMP}/brewy-ci-changed-paths"
+          git diff --name-only -z "${BASE_SHA}...HEAD" > "${CHANGED_PATHS_FILE}"
+          while IFS= read -r -d '' path; do
+            if [[ "${HAS_TRUSTED_ROUTER}" == "true" ]]; then
+              if [[ "${path}" == "scripts/ci-path-routing.sh" ]]; then
+                select_all_ci_routes
+              else
+                route_ci_path "${path}"
+              fi
+            fi
+          done < "${CHANGED_PATHS_FILE}"
 
           if [[ "${NEEDS_LINT}" -eq 1 ]]; then
             add_check '{"name":"Lint","check":"lint","runner":"macos-26"}'
           fi
           if [[ "${NEEDS_TESTS}" -eq 1 ]]; then
-            add_check '{"name":"Test (Thread Sanitizer)","check":"test-tsan","runner":"macos-26","xcodebuild_flags":"-enableCodeCoverage YES -enableThreadSanitizer YES","result_bundle":"TestResults-TSAN","environment":"codecov"}'
-            # UI test runner is incompatible with ASan (crashes at launch); TSan covers the UI tests.
+            add_check '{"name":"Test (Thread Sanitizer)","check":"test-tsan","runner":"macos-26","xcodebuild_flags":"-only-testing:BrewyTests -enableCodeCoverage YES -enableThreadSanitizer YES","result_bundle":"TestResults-TSAN","environment":"codecov"}'
+            add_check '{"name":"Test (signed UI runner)","check":"test-ui","runner":"macos-26","xcodebuild_flags":"-only-testing:BrewyUITests","result_bundle":"TestResults-UI"}'
             add_check '{"name":"Test (Address Sanitizer)","check":"test-asan","runner":"macos-26","xcodebuild_flags":"-enableAddressSanitizer YES -skip-testing:BrewyUITests","result_bundle":"TestResults-ASAN"}'
             # Everything else builds Debug; without this leg the release workflow is the
             # first place Release-only breakage (optimization warnings, stray references
@@ -104,23 +124,16 @@ jobs:
             add_check '{"name":"Build (Release)","check":"build-release","runner":"macos-26"}'
           fi
 
-          if grep -qE '^Brewy/Models/|^scripts/brew-json-probe/|^\.github/workflows/(brew-json-probe|ci)\.yml$' <<< "${CHANGED}"; then
+          if [[ "${NEEDS_PROBE}" -eq 1 ]]; then
             add_check '{"name":"Build Brew JSON Probe","check":"probe-build","runner":"macos-26"}'
           fi
 
-          # Source or periphery-config changes: dead-code scan
-          if grep -qE '\.swift$|^Brewy\.xcodeproj/|^\.periphery\.yml$|^\.github/workflows/ci\.yml$' <<< "${CHANGED}"; then
+          if [[ "${NEEDS_PERIPHERY}" -eq 1 ]]; then
             add_check '{"name":"Periphery","check":"periphery","runner":"macos-26"}'
           fi
 
-          # Source changes: CodeQL (excludes xcodeproj-only changes like version bumps)
-          if grep -qE '^Brewy/|^BrewyTests/|^BrewyUITests/' <<< "${CHANGED}"; then
-            RUN_CODEQL=true
-          fi
-
-          # Workflow changes: Actions security audit
-          if grep -qE '^\.github/workflows/' <<< "${CHANGED}"; then
-            RUN_ZIZMOR=true
+          if [[ "${NEEDS_RELEASE_HELPERS}" -eq 1 ]]; then
+            add_check '{"name":"Release helper validation","check":"release-helpers","runner":"ubuntu-slim"}'
           fi
 
           {
@@ -165,6 +178,10 @@ jobs:
         if: matrix.check == 'probe-build'
         run: bash scripts/brew-json-probe/build.sh /tmp/brew-json-probe
 
+      - name: Validate release helpers
+        if: matrix.check == 'release-helpers'
+        run: python3 scripts/validate-release-helpers.py
+
       - name: Restore Homebrew downloads
         id: homebrew-cache
         if: matrix.check == 'lint' || matrix.check == 'periphery'
@@ -200,6 +217,10 @@ jobs:
       - name: Typos
         if: matrix.check == 'lint'
         run: typos
+
+      - name: Validate CI path routing
+        if: matrix.check == 'lint'
+        run: bash scripts/ci-path-routing.sh --self-test
 
       - name: Install Periphery
         if: matrix.check == 'periphery'
@@ -245,12 +266,28 @@ jobs:
       - name: Test
         if: startsWith(matrix.check, 'test-')
         env:
+          MATRIX_CHECK: ${{ matrix.check }}
           XCODEBUILD_FLAGS: ${{ matrix.xcodebuild_flags }}
           RESULT_BUNDLE: ${{ matrix.result_bundle }}
         run: |
           EXTRA_XCODEBUILD_FLAGS=()
           if [[ -n "${XCODEBUILD_FLAGS}" ]]; then
             read -r -a EXTRA_XCODEBUILD_FLAGS <<< "${XCODEBUILD_FLAGS}"
+          fi
+          if [[ "${MATRIX_CHECK}" == "test-ui" ]]; then
+            SIGNING_FLAGS=(
+              CODE_SIGN_STYLE=Manual
+              CODE_SIGN_IDENTITY=-
+              CODE_SIGNING_REQUIRED=YES
+              CODE_SIGNING_ALLOWED=YES
+              DEVELOPMENT_TEAM=
+            )
+          else
+            SIGNING_FLAGS=(
+              CODE_SIGN_IDENTITY=
+              CODE_SIGNING_REQUIRED=NO
+              CODE_SIGNING_ALLOWED=NO
+            )
           fi
           xcodebuild test \
             -project Brewy.xcodeproj \
@@ -259,11 +296,27 @@ jobs:
             -derivedDataPath ./DerivedData \
             "${EXTRA_XCODEBUILD_FLAGS[@]}" \
             -resultBundlePath "${RESULT_BUNDLE}.xcresult" \
-            CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
+            "${SIGNING_FLAGS[@]}" \
             SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
             EXCLUDED_ARCHS=x86_64
+
+      - name: Verify UI test runner signature
+        if: success() && matrix.check == 'test-ui'
+        env:
+          RESULT_BUNDLE: ${{ matrix.result_bundle }}
+        run: |
+          BREWY_APP=$(find ./DerivedData/Build/Products -name 'Brewy.app' -type d -print -quit)
+          UI_TEST_BUNDLE=$(find ./DerivedData/Build/Products -name 'BrewyUITests.xctest' -type d -print -quit)
+          RUNNER_APP=$(find ./DerivedData/Build/Products -name 'BrewyUITests-Runner.app' -type d -print -quit)
+          test -n "${BREWY_APP}"
+          test -n "${UI_TEST_BUNDLE}"
+          test -n "${RUNNER_APP}"
+          codesign --verify --deep --strict --verbose=2 "${BREWY_APP}"
+          codesign --verify --strict --verbose=2 "${UI_TEST_BUNDLE}"
+          codesign --verify --deep --strict --verbose=2 "${RUNNER_APP}"
+          xcrun xcresulttool get test-results summary \
+            --path "${RESULT_BUNDLE}.xcresult" --compact |
+            python3 -c 'import json, sys; assert json.load(sys.stdin)["totalTestCount"] > 0'
 
       - name: Coverage Summary
         if: success() && matrix.check == 'test-tsan'
@@ -373,7 +426,7 @@ jobs:
 
   conclusion:
     name: conclusion
-    needs: [commits, check, codeql, zizmor]
+    needs: [generate-matrix, commits, check, codeql, zizmor]
     runs-on: ubuntu-slim
     timeout-minutes: 15
     if: always()
@@ -384,8 +437,30 @@ jobs:
           CHECK_RESULT: ${{ needs.check.result }}
           CODEQL_RESULT: ${{ needs.codeql.result }}
           ZIZMOR_RESULT: ${{ needs.zizmor.result }}
+          GENERATOR_RESULT: ${{ needs.generate-matrix.result }}
+          MATRIX: ${{ needs.generate-matrix.outputs.matrix }}
+          RUN_CODEQL: ${{ needs.generate-matrix.outputs.run_codeql }}
+          RUN_ZIZMOR: ${{ needs.generate-matrix.outputs.run_zizmor }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          test "${COMMITS_RESULT}" = "success" || test "${COMMITS_RESULT}" = "skipped"
-          test "${CHECK_RESULT}" = "success" || test "${CHECK_RESULT}" = "skipped"
-          test "${CODEQL_RESULT}" = "success" || test "${CODEQL_RESULT}" = "skipped"
-          test "${ZIZMOR_RESULT}" = "success" || test "${ZIZMOR_RESULT}" = "skipped"
+          test "${GENERATOR_RESULT}" = "success"
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            test "${COMMITS_RESULT}" = "success"
+          else
+            test "${COMMITS_RESULT}" = "skipped"
+          fi
+          if [[ "${MATRIX}" == "[]" ]]; then
+            test "${CHECK_RESULT}" = "skipped"
+          else
+            test "${CHECK_RESULT}" = "success"
+          fi
+          if [[ "${RUN_CODEQL}" == "true" ]]; then
+            test "${CODEQL_RESULT}" = "success"
+          else
+            test "${CODEQL_RESULT}" = "skipped"
+          fi
+          if [[ "${RUN_ZIZMOR}" == "true" ]]; then
+            test "${ZIZMOR_RESULT}" = "success"
+          else
+            test "${ZIZMOR_RESULT}" = "skipped"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Extract version from Xcode project
@@ -75,19 +76,33 @@ jobs:
           echo "build_number=${BUILD_NUMBER}" >> "${GITHUB_OUTPUT}"
           echo "TAG=${TAG}" >> "${GITHUB_ENV}"
 
-      - name: Ensure release tag is available
+      - name: Ensure release can start or resume
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          if gh release view "${TAG}" --repo "${REPOSITORY}" >/dev/null 2>&1; then
-            echo "::error::Release ${TAG} already exists."
-            exit 1
+          if RELEASE_STATE=$(gh release view "${TAG}" \
+            --repo "${REPOSITORY}" \
+            --json isDraft,targetCommitish \
+            --jq '[.isDraft, .targetCommitish] | @tsv' 2>/dev/null); then
+            IFS=$'\t' read -r IS_DRAFT TARGET_COMMITISH <<< "${RELEASE_STATE}"
+            if [[ "${IS_DRAFT}" != "true" ]]; then
+              echo "::error::Release ${TAG} is already published; published assets are immutable."
+              exit 1
+            fi
+            if [[ "${TARGET_COMMITISH}" != "${GITHUB_SHA}" ]]; then
+              echo "::error::Draft ${TAG} targets ${TARGET_COMMITISH}, not dispatch commit ${GITHUB_SHA}."
+              exit 1
+            fi
+            echo "Draft ${TAG} targets this dispatch commit; continuing the retry."
+            exit 0
           fi
+
           if gh api "repos/${REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
-            echo "::error::Tag ${TAG} already exists."
+            echo "::error::Tag ${TAG} exists without a GitHub release; refusing to adopt it."
             exit 1
           fi
+          gh api "repos/${REPOSITORY}" >/dev/null
 
       - name: Create and unlock temporary macOS keychain
         run: |
@@ -266,33 +281,54 @@ jobs:
           echo "SPARKLE_SIG=$(echo "${SIG_OUTPUT}" | grep -o 'sparkle:edSignature="[^"]*"' | cut -d'"' -f2)" >> "${GITHUB_ENV}"
           echo "SPARKLE_LENGTH=$(echo "${SIG_OUTPUT}" | grep -o 'length="[^"]*"' | cut -d'"' -f2)" >> "${GITHUB_ENV}"
 
-      - name: Create release with generated notes
+      - name: Create or update draft release asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACT_NAME: ${{ needs.build.outputs.artifact_name }}
           REPOSITORY: ${{ github.repository }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
-          gh release create "${TAG}" \
+          if RELEASE_STATE=$(gh release view "${TAG}" \
             --repo "${REPOSITORY}" \
-            --target "${COMMIT_SHA}" \
-            --title "${TAG}" \
-            --generate-notes \
-            "${ARTIFACT_NAME}"
-          gh release view "${TAG}" \
-            --repo "${REPOSITORY}" \
-            --json body \
+            --json isDraft,targetCommitish \
+            --jq '[.isDraft, .targetCommitish] | @tsv' 2>/dev/null); then
+            IFS=$'\t' read -r IS_DRAFT TARGET_COMMITISH <<< "${RELEASE_STATE}"
+            if [[ "${IS_DRAFT}" != "true" ]]; then
+              echo "::error::Release ${TAG} was published before asset upload; refusing to replace it."
+              exit 1
+            fi
+            if [[ "${TARGET_COMMITISH}" != "${COMMIT_SHA}" ]]; then
+              echo "::error::Draft ${TAG} targets ${TARGET_COMMITISH}, not dispatch commit ${COMMIT_SHA}."
+              exit 1
+            fi
+            gh release upload "${TAG}" "${ARTIFACT_NAME}" --repo "${REPOSITORY}" --clobber
+          else
+            if gh api "repos/${REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+              echo "::error::Tag ${TAG} exists without a GitHub release; refusing to adopt it."
+              exit 1
+            fi
+            gh release create "${TAG}" \
+              --repo "${REPOSITORY}" \
+              --target "${COMMIT_SHA}" \
+              --title "${TAG}" \
+              --draft \
+              --generate-notes \
+              "${ARTIFACT_NAME}"
+          fi
+          gh api --method POST "repos/${REPOSITORY}/releases/generate-notes" \
+            -f tag_name="${TAG}" \
+            -f target_commitish="${COMMIT_SHA}" \
             --jq '.body' > "${RUNNER_TEMP}/raw_notes.md"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
+          ref: ${{ github.sha }}
           persist-credentials: false
 
+      - name: Verify release helper revision
+        run: test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+
       - name: Format release notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
         run: |
           python3 .github/format-release-notes.py \
             "${RUNNER_TEMP}/raw_notes.md" "${TAG}" \
@@ -300,6 +336,22 @@ jobs:
           python3 .github/format-release-notes.py \
             "${RUNNER_TEMP}/raw_notes.md" "${TAG}" --html \
             > "${RUNNER_TEMP}/release_notes.html"
+
+      - name: Update release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          RELEASE_STATE=$(gh release view "${TAG}" \
+            --repo "${REPOSITORY}" \
+            --json isDraft,targetCommitish \
+            --jq '[.isDraft, .targetCommitish] | @tsv')
+          IFS=$'\t' read -r IS_DRAFT TARGET_COMMITISH <<< "${RELEASE_STATE}"
+          if [[ "${IS_DRAFT}" != "true" || "${TARGET_COMMITISH}" != "${COMMIT_SHA}" ]]; then
+            echo "::error::Release ${TAG} is no longer the matching retryable draft."
+            exit 1
+          fi
           gh release edit "${TAG}" \
             --repo "${REPOSITORY}" \
             --notes-file "${RUNNER_TEMP}/formatted_notes.md"
@@ -317,6 +369,24 @@ jobs:
           envsubst "\$TAG \$PUBDATE \$BUILD_NUMBER \$DOWNLOAD_URL \$SPARKLE_LENGTH \$SPARKLE_SIG \$RELEASE_NOTES_HTML" \
             < .github/appcast-template.xml > appcast.xml
 
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          RELEASE_STATE=$(gh release view "${TAG}" \
+            --repo "${REPOSITORY}" \
+            --json isDraft,targetCommitish \
+            --jq '[.isDraft, .targetCommitish] | @tsv')
+          IFS=$'\t' read -r IS_DRAFT TARGET_COMMITISH <<< "${RELEASE_STATE}"
+          if [[ "${IS_DRAFT}" != "true" || "${TARGET_COMMITISH}" != "${COMMIT_SHA}" ]]; then
+            echo "::error::Release ${TAG} is no longer the matching retryable draft."
+            exit 1
+          fi
+          gh release edit "${TAG}" --repo "${REPOSITORY}" --draft=false
+          test "$(gh release view "${TAG}" --repo "${REPOSITORY}" --json isDraft --jq '.isDraft')" = "false"
+
       - name: Push appcast
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -331,7 +401,7 @@ jobs:
           cp "${RUNNER_TEMP}/appcast.xml" appcast.xml
           git add appcast.xml
           git diff --cached --quiet && exit 0
-          git commit -m "Update appcast for ${TAG}"
+          git commit --signoff -m "Update appcast for ${TAG}"
           git -c "http.extraheader=AUTHORIZATION: Basic ${AUTH_HEADER}" push origin appcast
 
   bump-cask:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Please follow these guidelines when contributing.
 
 - `Brewy/BrewyApp.swift`: app entry point, window commands, menu bar extra, Sparkle updater.
 - `Brewy/Models/BrewService*.swift`: central state container and Homebrew orchestration split by responsibility.
-- `Brewy/Models/CommandRunner.swift`: the single process-execution path for `brew`, `mas`, `du`, `osascript`, and other executables.
+- `Brewy/Models/CommandRunner.swift`: the single process-execution path for `brew`, `mas`, `du`, and other executables.
 - `Brewy/Models/BrewJSONTypes.swift`: Homebrew JSON v2 Codable response types.
 - `Brewy/Models/MasService.swift`: Mac App Store integration through `mas`.
 - `Brewy/Models/ServicesService.swift`: Homebrew services parsing and control.

--- a/Brewy/Models/ActionHistoryEntry+Commands.swift
+++ b/Brewy/Models/ActionHistoryEntry+Commands.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 extension ActionHistoryEntry {
+    var isRetryable: Bool {
+        guard status == .failure, !arguments.isEmpty else { return false }
+        guard arguments.first == "bundle" else { return true }
+        return isBundleDump && bundleDumpURL != nil
+    }
+
     var isMutatingCommand: Bool {
         if isBundleDump { return true }
         guard let command = arguments.first else { return false }

--- a/Brewy/Models/AppcastParser.swift
+++ b/Brewy/Models/AppcastParser.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+final class AppcastParser: NSObject, XMLParserDelegate {
+    static let maximumFeedByteCount = 1_048_576
+    static let maximumDescriptionByteCount = 524_288
+    private static let maximumTitleByteCount = 4_096
+    private static let maximumDateByteCount = 1_024
+    private static let maximumVersionByteCount = 256
+
+    private var currentElement = ""
+    private var currentTitle = ""
+    private var currentPubDate = ""
+    private var currentVersion = ""
+    private var currentDescription = ""
+    private var release: AppcastRelease?
+    private var insideItem = false
+    private var currentTitleByteCount = 0
+    private var currentPubDateByteCount = 0
+    private var currentVersionByteCount = 0
+    private var currentDescriptionByteCount = 0
+    private var rejected = false
+
+    func parse(data: Data) -> AppcastRelease? {
+        guard data.count <= Self.maximumFeedByteCount else { return nil }
+        currentElement = ""
+        currentTitle = ""
+        currentPubDate = ""
+        currentVersion = ""
+        currentDescription = ""
+        release = nil
+        insideItem = false
+        rejected = false
+        resetFieldCounts()
+
+        let parser = XMLParser(data: data)
+        parser.delegate = self
+        parser.shouldResolveExternalEntities = false
+        _ = parser.parse()
+        return rejected ? nil : release
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName: String?,
+        attributes: [String: String] = [:]
+    ) {
+        currentElement = elementName
+        if elementName == "item" {
+            insideItem = true
+            currentTitle = ""
+            currentPubDate = ""
+            currentVersion = ""
+            currentDescription = ""
+            resetFieldCounts()
+        }
+    }
+
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        guard insideItem else { return }
+        switch currentElement {
+        case "title":
+            append(
+                string,
+                to: &currentTitle,
+                byteCount: &currentTitleByteCount,
+                limit: Self.maximumTitleByteCount,
+                parser: parser
+            )
+        case "pubDate":
+            append(
+                string,
+                to: &currentPubDate,
+                byteCount: &currentPubDateByteCount,
+                limit: Self.maximumDateByteCount,
+                parser: parser
+            )
+        case "sparkle:shortVersionString":
+            append(
+                string,
+                to: &currentVersion,
+                byteCount: &currentVersionByteCount,
+                limit: Self.maximumVersionByteCount,
+                parser: parser
+            )
+        case "description":
+            append(
+                string,
+                to: &currentDescription,
+                byteCount: &currentDescriptionByteCount,
+                limit: Self.maximumDescriptionByteCount,
+                parser: parser
+            )
+        default: break
+        }
+    }
+
+    func parser(_ parser: XMLParser, foundCDATA CDATABlock: Data) {
+        guard insideItem, currentElement == "description" else { return }
+        if let text = String(data: CDATABlock, encoding: .utf8) {
+            append(
+                text,
+                to: &currentDescription,
+                byteCount: &currentDescriptionByteCount,
+                limit: Self.maximumDescriptionByteCount,
+                parser: parser
+            )
+        }
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        foundInternalEntityDeclarationWithName name: String,
+        value: String?
+    ) {
+        rejected = true
+        parser.abortParsing()
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        foundExternalEntityDeclarationWithName name: String,
+        publicID: String?,
+        systemID: String?
+    ) {
+        rejected = true
+        parser.abortParsing()
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName: String?
+    ) {
+        if elementName == "item" {
+            if release == nil {
+                release = AppcastRelease(
+                    title: currentTitle.trimmingCharacters(in: .whitespacesAndNewlines),
+                    pubDate: currentPubDate.trimmingCharacters(in: .whitespacesAndNewlines),
+                    version: currentVersion.trimmingCharacters(in: .whitespacesAndNewlines),
+                    descriptionHTML: currentDescription.isEmpty ? nil : currentDescription
+                )
+            }
+            insideItem = false
+            parser.abortParsing()
+        }
+        currentElement = ""
+    }
+
+    private func append(
+        _ text: String,
+        to field: inout String,
+        byteCount: inout Int,
+        limit: Int,
+        parser: XMLParser
+    ) {
+        let addedByteCount = text.utf8.count
+        guard addedByteCount <= limit - byteCount else {
+            rejected = true
+            parser.abortParsing()
+            return
+        }
+        field += text
+        byteCount += addedByteCount
+    }
+
+    private func resetFieldCounts() {
+        currentTitleByteCount = 0
+        currentPubDateByteCount = 0
+        currentVersionByteCount = 0
+        currentDescriptionByteCount = 0
+    }
+}

--- a/Brewy/Models/BrewJSONTypes.swift
+++ b/Brewy/Models/BrewJSONTypes.swift
@@ -60,6 +60,7 @@ struct CaskJSON: Decodable {
     let homepage: String?
     let url: String?
     let dependencies: [String]
+    let dependencyReferences: [PackageReference]
     let artifacts: [CaskArtifactJSON]
 
     enum CodingKeys: String, CodingKey {
@@ -84,7 +85,11 @@ struct CaskJSON: Decodable {
         // `depends_on` is usually an object but brew sometimes emits an empty array; tolerate
         // either shape so a cask never fails to decode over its dependency field.
         let deps = try? container.decodeIfPresent(DependsOn.self, forKey: .dependsOn)
-        dependencies = (deps?.formula ?? []) + (deps?.cask ?? [])
+        let formulaDependencies = deps?.formula ?? []
+        let caskDependencies = deps?.cask ?? []
+        dependencies = formulaDependencies + caskDependencies
+        dependencyReferences = formulaDependencies.map { PackageReference(name: $0, source: .formula) }
+            + caskDependencies.map { PackageReference(name: $0, source: .cask) }
     }
 
     var applicationBundleURLs: [URL] {
@@ -112,6 +117,7 @@ struct CaskJSON: Decodable {
             pinned: false,
             installedOnRequest: true,
             dependencies: dependencies,
+            dependencyReferences: dependencyReferences,
             repositoryURL: repositoryURL
         )
     }

--- a/Brewy/Models/BrewService+Bundle.swift
+++ b/Brewy/Models/BrewService+Bundle.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 import OSLog
 
@@ -103,7 +102,7 @@ enum BrewfileDiscovery {
     private static func existingURL(atPath path: String, fileExists: (String) -> Bool) -> URL? {
         let expanded = expandedPath(path)
         guard fileExists(expanded) else { return nil }
-        return URL(fileURLWithPath: expanded).resolvingSymlinksInPath()
+        return URL(fileURLWithPath: expanded).standardizedFileURL
     }
 
     private static func expandedPath(_ path: String) -> String {
@@ -200,9 +199,9 @@ extension BrewService {
         guard !isBundleLoading, bundleCheckStatus != .checking else { return }
         lastError = nil
         guard let brewfileURL = resolveBrewfile() else { return }
-        guard canExecuteBrewfile(brewfileURL) else { return }
-        guard await fetchBundleEntries(brewfileURL: brewfileURL) else { return }
-        await checkBundle(brewfileURL: brewfileURL)
+        guard let snapshot = executableSnapshot(for: brewfileURL) else { return }
+        guard await fetchBundleEntries(snapshot: snapshot) else { return }
+        await checkBundle(snapshot: snapshot)
     }
 
     func updateBundleEntryStatuses() {
@@ -220,14 +219,18 @@ extension BrewService {
 
     @discardableResult
     func fetchBundleEntries(brewfileURL: URL) async -> Bool {
-        guard canExecuteBrewfile(brewfileURL) else { return false }
+        guard let snapshot = executableSnapshot(for: brewfileURL) else { return false }
+        return await fetchBundleEntries(snapshot: snapshot)
+    }
+
+    private func fetchBundleEntries(snapshot: BrewfileSnapshot) async -> Bool {
         isBundleLoading = true
         defer { isBundleLoading = false }
 
         var fetchedEntries: [BrewBundleEntry] = []
         for type in BrewBundleEntryType.allCases {
-            let arguments = ["bundle", "list", type.listFlag, "--file", brewfileURL.path]
-            let result = await runBrewCommand(arguments)
+            let arguments = ["bundle", "list", type.listFlag, "--file=-"]
+            let result = await runBrewCommand(arguments, standardInput: snapshot.data)
             guard result.success else {
                 logger.warning("Failed to list \(type.rawValue) bundle entries: \(result.output.prefix(200))")
                 let message = BrewError.commandFailed(
@@ -253,10 +256,14 @@ extension BrewService {
     }
 
     func checkBundle(brewfileURL: URL) async {
-        guard canExecuteBrewfile(brewfileURL) else { return }
+        guard let snapshot = executableSnapshot(for: brewfileURL) else { return }
+        await checkBundle(snapshot: snapshot)
+    }
+
+    private func checkBundle(snapshot: BrewfileSnapshot) async {
         bundleCheckStatus = .checking
-        let arguments = ["bundle", "check", "--verbose", "--file", brewfileURL.path]
-        let result = await runBrewCommand(arguments)
+        let arguments = ["bundle", "check", "--verbose", "--file=-"]
+        let result = await runBrewCommand(arguments, standardInput: snapshot.data)
         let status = BrewBundleParser.parseCheckResult(success: result.success, output: result.output)
         bundleCheckStatus = status
 
@@ -278,39 +285,98 @@ extension BrewService {
         isPerformingAction = true
         actionOutput = ""
         lastError = nil
+        defer { isPerformingAction = false }
 
-        let arguments = ["bundle", "dump", "--force", "--file", url.path]
-        let result = await runBrewCommandStreaming(arguments)
-        if !result.success, !result.cancelled {
-            logger.warning("Bundle dump failed: \(result.output.prefix(200))")
-            lastError = .commandFailed(command: arguments.joined(separator: " "), output: result.output)
-        }
-        recordAction(arguments: arguments, packageName: nil, packageSource: nil, success: result.success, output: result.output)
-        isPerformingAction = false
+        let recordedArguments = ["bundle", "dump", "--force", "--file", url.path]
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Brewy-Brewfile-\(UUID().uuidString)", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(
+                at: temporaryDirectory,
+                withIntermediateDirectories: false,
+                attributes: [.posixPermissions: 0o700]
+            )
+            defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
-        if result.success {
+            let generatedURL = temporaryDirectory.appendingPathComponent("Brewfile")
+            let executionArguments = ["bundle", "dump", "--force", "--file", generatedURL.path]
+            let executionResult = await runBrewCommand(executionArguments)
+            guard executionResult.success else {
+                return handleBundleDumpFailure(executionResult, arguments: recordedArguments)
+            }
+
+            let generatedSnapshot = try BrewfileSnapshot.read(from: generatedURL)
+            let snapshot = try BrewfileSnapshot(
+                sourcePath: url.standardizedFileURL.path,
+                data: generatedSnapshot.data
+            )
+            try generatedSnapshot.data.write(to: url, options: .atomic)
             customBrewfilePath = url.path
-            trustBrewfile(at: url)
+            adoptTrustedSnapshot(snapshot)
+            let result = CommandResult(output: "Created Brewfile at \(url.path).", success: true)
+            actionOutput = result.output
+            recordAction(
+                arguments: recordedArguments,
+                packageName: nil,
+                packageSource: nil,
+                success: true,
+                output: result.output
+            )
             await refreshBundle()
+            return result
+        } catch {
+            let message = "Unable to write Brewfile at \(url.path): \(error.localizedDescription)"
+            let result = CommandResult(output: message, success: false)
+            lastError = .commandFailed(command: recordedArguments.joined(separator: " "), output: message)
+            recordAction(
+                arguments: recordedArguments,
+                packageName: nil,
+                packageSource: nil,
+                success: false,
+                output: message
+            )
+            return result
         }
+    }
+
+    private func handleBundleDumpFailure(
+        _ result: CommandResult,
+        arguments: [String]
+    ) -> CommandResult {
+        if !result.cancelled {
+            logger.warning("Bundle dump failed: \(result.output.prefix(200))")
+            lastError = .commandFailed(
+                command: arguments.joined(separator: " "),
+                output: result.output
+            )
+        }
+        recordAction(
+            arguments: arguments,
+            packageName: nil,
+            packageSource: nil,
+            success: false,
+            output: result.output
+        )
         return result
     }
 
     @discardableResult
     func trustBrewfile(at url: URL) -> Bool {
-        let resolvedURL = url.resolvingSymlinksInPath()
-        guard let digest = Self.brewfileDigest(at: resolvedURL) else {
-            let message = "Unable to read Brewfile at \(url.path)."
+        do {
+            let snapshot = try BrewfileSnapshot.read(from: url)
+            adoptTrustedSnapshot(snapshot)
+            if brewfileURL?.standardizedFileURL.path == snapshot.sourcePath,
+               bundleCheckStatus == .untrusted {
+                bundleCheckStatus = .unknown
+            }
+            return true
+        } catch {
+            brewfileSnapshot = nil
+            let message = "Unable to trust Brewfile at \(url.path): \(error.localizedDescription)"
             bundleCheckStatus = .failed(message)
             lastError = .commandFailed(command: "bundle trust", output: message)
             return false
         }
-        trustedBrewfilePath = resolvedURL.path
-        trustedBrewfileDigest = digest
-        if brewfileURL?.path == resolvedURL.path, bundleCheckStatus == .untrusted {
-            bundleCheckStatus = .unknown
-        }
-        return true
     }
 
     func trustCurrentBrewfileAndRefresh() async {
@@ -341,28 +407,31 @@ extension BrewService {
         }
     }
 
-    private func canExecuteBrewfile(_ url: URL) -> Bool {
-        guard isTrustedBrewfile(url) else {
+    private func executableSnapshot(for url: URL) -> BrewfileSnapshot? {
+        guard let snapshot = trustedSnapshot(for: url) else {
             bundleEntries = []
             bundleCheckStatus = .untrusted
-            return false
+            return nil
         }
-        return true
+        return snapshot
     }
 
     private func isTrustedBrewfile(_ url: URL) -> Bool {
-        // Homebrew Bundle only accepts a path, so recheck trust immediately before launch.
-        guard trustedBrewfilePath == url.path,
-              let digest = Self.brewfileDigest(at: url) else {
-            return false
-        }
-        return trustedBrewfileDigest == digest
+        trustedSnapshot(for: url) != nil
     }
 
-    private static func brewfileDigest(at url: URL) -> String? {
-        guard let data = try? Data(contentsOf: url) else { return nil }
-        return SHA256.hash(data: data)
-            .map { String(format: "%02x", $0) }
-            .joined()
+    private func trustedSnapshot(for url: URL) -> BrewfileSnapshot? {
+        let sourcePath = url.standardizedFileURL.path
+        guard trustedBrewfilePath == sourcePath else { return nil }
+        guard let snapshot = try? BrewfileSnapshot.read(from: url),
+              snapshot.digest == trustedBrewfileDigest else { return nil }
+        brewfileSnapshot = snapshot
+        return snapshot
+    }
+
+    private func adoptTrustedSnapshot(_ snapshot: BrewfileSnapshot) {
+        brewfileSnapshot = snapshot
+        trustedBrewfilePath = snapshot.sourcePath
+        trustedBrewfileDigest = snapshot.digest
     }
 }

--- a/Brewy/Models/BrewService+DependencyTree.swift
+++ b/Brewy/Models/BrewService+DependencyTree.swift
@@ -8,49 +8,94 @@ private struct DependencyWalk {
 }
 
 extension BrewService {
-    /// Recursive reverse-dependency tree: walks upward through installed packages that depend on `name`.
+    func dependents(of reference: PackageReference) -> [BrewPackage] {
+        reverseDependencies[reference.id] ?? []
+    }
+
+    func dependents(of name: String, source: PackageSource = .formula) -> [BrewPackage] {
+        dependents(of: PackageReference(name: name, source: source))
+    }
+
+    /// Recursive reverse-dependency tree: walks upward through installed packages that depend on `package`.
     /// Use this to answer "where does this package come from?" — the leaves are the user-requested
     /// installs that ultimately pulled this in.
     /// `maxNodes` bounds the total node count so a widely-shared package (e.g. a hub like
     /// `ca-certificates`) can't generate an unbounded tree that stalls rendering.
-    func reverseDependencyTree(for name: String, maxDepth: Int = 8, maxNodes: Int = 300) -> [DependencyTreeNode] {
-        var walk = DependencyWalk(ancestors: [name], budget: maxNodes)
-        return buildReverseTree(name: name, prefix: name, walk: &walk, remaining: maxDepth)
+    func reverseDependencyTree(
+        for package: BrewPackage,
+        maxDepth: Int = 8,
+        maxNodes: Int = 300
+    ) -> [DependencyTreeNode] {
+        reverseDependencyTree(
+            for: PackageReference(name: package.name, source: package.source),
+            maxDepth: maxDepth,
+            maxNodes: maxNodes
+        )
     }
 
-    /// Recursive forward-dependency tree: walks downward through what `name` depends on.
+    func reverseDependencyTree(
+        for name: String,
+        source: PackageSource = .formula,
+        maxDepth: Int = 8,
+        maxNodes: Int = 300
+    ) -> [DependencyTreeNode] {
+        reverseDependencyTree(
+            for: PackageReference(name: name, source: source),
+            maxDepth: maxDepth,
+            maxNodes: maxNodes
+        )
+    }
+
+    /// Recursive forward-dependency tree: walks downward through what `package` depends on.
     /// Children of a not-installed dep are omitted since we only know dependencies for installed packages.
-    func forwardDependencyTree(for name: String, maxDepth: Int = 8, maxNodes: Int = 300) -> [DependencyTreeNode] {
-        guard let pkg = allInstalled.first(where: { $0.name == name }) else { return [] }
-        var walk = DependencyWalk(ancestors: [name], budget: maxNodes)
-        // `allInstalled` can hold two entries with the same name (e.g. a `docker` formula and the
-        // `docker` cask), which would trap `Dictionary(uniqueKeysWithValues:)`. Keep the first —
-        // formulae precede casks, and brew dependencies resolve to formulae.
-        let lookup = Dictionary(allInstalled.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
-        return buildForwardTree(deps: pkg.dependencies, prefix: name, lookup: lookup, walk: &walk, remaining: maxDepth)
+    func forwardDependencyTree(
+        for package: BrewPackage,
+        maxDepth: Int = 8,
+        maxNodes: Int = 300
+    ) -> [DependencyTreeNode] {
+        forwardDependencyTree(forID: package.id, maxDepth: maxDepth, maxNodes: maxNodes)
+    }
+
+    func forwardDependencyTree(
+        for name: String,
+        source: PackageSource = .formula,
+        maxDepth: Int = 8,
+        maxNodes: Int = 300
+    ) -> [DependencyTreeNode] {
+        forwardDependencyTree(
+            forID: PackageReference(name: name, source: source).id,
+            maxDepth: maxDepth,
+            maxNodes: maxNodes
+        )
     }
 
     private func buildReverseTree(
-        name: String, prefix: String, walk: inout DependencyWalk, remaining: Int
+        reference: PackageReference, prefix: String, walk: inout DependencyWalk, remaining: Int
     ) -> [DependencyTreeNode] {
         guard remaining > 0 else { return [] }
         var nodes: [DependencyTreeNode] = []
-        for parent in dependents(of: name) {
+        for parent in dependents(of: reference) {
             guard walk.budget > 0 else { break }
             walk.budget -= 1
-            let path = "\(prefix)>\(parent.name)"
-            let isCycle = walk.ancestors.contains(parent.name)
+            let path = "\(prefix)>\(parent.id)"
+            let isCycle = walk.ancestors.contains(parent.id)
             let children: [DependencyTreeNode]?
             if isCycle {
                 children = nil
             } else {
-                walk.ancestors.insert(parent.name)
-                let kids = buildReverseTree(name: parent.name, prefix: path, walk: &walk, remaining: remaining - 1)
-                walk.ancestors.remove(parent.name)
+                walk.ancestors.insert(parent.id)
+                let parentReference = PackageReference(name: parent.name, source: parent.source)
+                let kids = buildReverseTree(
+                    reference: parentReference,
+                    prefix: path,
+                    walk: &walk,
+                    remaining: remaining - 1
+                )
+                walk.ancestors.remove(parent.id)
                 children = kids.isEmpty ? nil : kids
             }
             nodes.append(DependencyTreeNode(
-                id: path, name: parent.name,
+                id: path, name: parent.name, packageID: parent.id,
                 isInstalled: true, installedOnRequest: parent.installedOnRequest,
                 isCycle: isCycle, children: children
             ))
@@ -59,34 +104,69 @@ extension BrewService {
     }
 
     private func buildForwardTree(
-        deps: [String], prefix: String, lookup: [String: BrewPackage], walk: inout DependencyWalk, remaining: Int
+        dependencies: [PackageReference],
+        prefix: String,
+        lookup: [String: BrewPackage],
+        walk: inout DependencyWalk,
+        remaining: Int
     ) -> [DependencyTreeNode] {
         guard remaining > 0 else { return [] }
         var nodes: [DependencyTreeNode] = []
-        for depName in deps {
+        for dependency in dependencies {
             guard walk.budget > 0 else { break }
             walk.budget -= 1
-            let path = "\(prefix)>\(depName)"
-            let isCycle = walk.ancestors.contains(depName)
-            let installedPkg = lookup[depName]
+            let path = "\(prefix)>\(dependency.id)"
+            let isCycle = walk.ancestors.contains(dependency.id)
+            let installedPackage = lookup[dependency.id]
             let children: [DependencyTreeNode]?
-            if !isCycle, let installedPkg {
-                walk.ancestors.insert(depName)
+            if !isCycle, let installedPackage {
+                walk.ancestors.insert(dependency.id)
                 let kids = buildForwardTree(
-                    deps: installedPkg.dependencies, prefix: path, lookup: lookup, walk: &walk, remaining: remaining - 1
+                    dependencies: installedPackage.dependencyReferences,
+                    prefix: path,
+                    lookup: lookup,
+                    walk: &walk,
+                    remaining: remaining - 1
                 )
-                walk.ancestors.remove(depName)
+                walk.ancestors.remove(dependency.id)
                 children = kids.isEmpty ? nil : kids
             } else {
                 children = nil
             }
             nodes.append(DependencyTreeNode(
-                id: path, name: depName,
-                isInstalled: installedPkg != nil,
-                installedOnRequest: installedPkg?.installedOnRequest ?? false,
+                id: path, name: dependency.name, packageID: installedPackage?.id,
+                isInstalled: installedPackage != nil,
+                installedOnRequest: installedPackage?.installedOnRequest ?? false,
                 isCycle: isCycle, children: children
             ))
         }
         return nodes
+    }
+
+    private func reverseDependencyTree(
+        for reference: PackageReference,
+        maxDepth: Int,
+        maxNodes: Int
+    ) -> [DependencyTreeNode] {
+        var walk = DependencyWalk(ancestors: [reference.id], budget: maxNodes)
+        return buildReverseTree(
+            reference: reference,
+            prefix: reference.id,
+            walk: &walk,
+            remaining: maxDepth
+        )
+    }
+
+    private func forwardDependencyTree(forID id: String, maxDepth: Int, maxNodes: Int) -> [DependencyTreeNode] {
+        guard let package = allInstalled.first(where: { $0.id == id }) else { return [] }
+        var walk = DependencyWalk(ancestors: [package.id], budget: maxNodes)
+        let lookup = Dictionary(allInstalled.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        return buildForwardTree(
+            dependencies: package.dependencyReferences,
+            prefix: package.id,
+            lookup: lookup,
+            walk: &walk,
+            remaining: maxDepth
+        )
     }
 }

--- a/Brewy/Models/BrewService+Groups.swift
+++ b/Brewy/Models/BrewService+Groups.swift
@@ -23,15 +23,12 @@ extension BrewService {
     private func saveGroups() {
         guard let url = Self.groupsURL,
               !BrewyRuntime.isRunningTests else { return }
-        let groups = packageGroups
-        Task.detached(priority: .utility) {
-            do {
-                let data = try JSONEncoder().encode(groups)
-                try data.write(to: url, options: .atomic)
-                logger.debug("Groups saved successfully")
-            } catch {
-                logger.error("Failed to save groups: \(error.localizedDescription)")
-            }
+        do {
+            let data = try JSONEncoder().encode(packageGroups)
+            try data.write(to: url, options: .atomic)
+            logger.debug("Groups saved successfully")
+        } catch {
+            logger.error("Failed to save groups: \(error.localizedDescription)")
         }
     }
 

--- a/Brewy/Models/BrewService+History.swift
+++ b/Brewy/Models/BrewService+History.swift
@@ -27,15 +27,12 @@ extension BrewService {
     private func saveHistory() {
         guard let url = Self.historyURL,
               !BrewyRuntime.isRunningTests else { return }
-        let history = actionHistory
-        Task.detached(priority: .utility) {
-            do {
-                let data = try JSONEncoder().encode(history)
-                try data.write(to: url, options: .atomic)
-                logger.debug("History saved successfully")
-            } catch {
-                logger.error("Failed to save history: \(error.localizedDescription)")
-            }
+        do {
+            let data = try JSONEncoder().encode(actionHistory)
+            try data.write(to: url, options: .atomic)
+            logger.debug("History saved successfully")
+        } catch {
+            logger.error("Failed to save history: \(error.localizedDescription)")
         }
     }
 
@@ -69,6 +66,10 @@ extension BrewService {
 
     func retryAction(_ entry: ActionHistoryEntry) async {
         guard entry.isRetryable else { return }
+        if entry.isBundleDump, let url = entry.bundleDumpURL {
+            _ = await dumpBundle(to: url)
+            return
+        }
         guard !isPerformingAction else {
             logger.info("Retry skipped, action already in progress")
             return
@@ -90,11 +91,7 @@ extension BrewService {
             output: result.output
         )
 
-        if result.success, entry.isBundleDump, let url = entry.bundleDumpURL {
-            customBrewfilePath = url.path
-            trustBrewfile(at: url)
-            await refreshBundle()
-        } else if entry.isMutatingCommand {
+        if result.success, entry.isMutatingCommand {
             await refresh()
         }
     }
@@ -123,6 +120,7 @@ extension BrewService {
             pinned: pkg.pinned || outdatedPkg.pinned,
             installedOnRequest: pkg.installedOnRequest,
             dependencies: pkg.dependencies,
+            dependencyReferences: pkg.dependencyReferences,
             repositoryURL: pkg.repositoryURL
         )
     }

--- a/Brewy/Models/BrewService+PackageDetail.swift
+++ b/Brewy/Models/BrewService+PackageDetail.swift
@@ -31,7 +31,8 @@ extension BrewService {
                         source: package.source,
                         pinned: package.pinned,
                         installedOnRequest: package.installedOnRequest,
-                        dependencies: package.dependencies,
+                        dependencies: cask.dependencies,
+                        dependencyReferences: cask.dependencyReferences,
                         repositoryURL: cask.repositoryURL ?? (cask.url == nil ? package.repositoryURL : nil)
                     )
                 }
@@ -50,6 +51,9 @@ extension BrewService {
                         pinned: package.pinned,
                         installedOnRequest: package.installedOnRequest,
                         dependencies: formula.dependencies ?? package.dependencies,
+                        dependencyReferences: formula.dependencies.map {
+                            $0.map { PackageReference(name: $0, source: .formula) }
+                        } ?? package.dependencyReferences,
                         repositoryURL: package.repositoryURL
                     )
                 }

--- a/Brewy/Models/BrewService+Streaming.swift
+++ b/Brewy/Models/BrewService+Streaming.swift
@@ -1,13 +1,16 @@
 extension BrewService {
     nonisolated static let actionOutputByteLimit = 262_144
 
-    /// Streams command output into a bounded display buffer. The returned result retains the
-    /// full output for error handling and byte-bounded history persistence.
+    /// Streams command output into a bounded display buffer. The command runner independently
+    /// bounds captured output used for error handling and history persistence.
     func runBrewCommandStreaming(_ arguments: [String]) async -> CommandResult {
         let brewPath = CommandRunner.resolvedBrewPath(preferred: customBrewPath)
         let timeout = CommandRunner.timeout(forBrewArguments: arguments)
         let baseline = actionOutput
-        let (stream, continuation) = AsyncStream.makeStream(of: String.self)
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: String.self,
+            bufferingPolicy: .bufferingNewest(64)
+        )
         // A single consumer applies chunks in arrival order; Task-per-chunk would not
         // guarantee ordering.
         let appender = Task { @MainActor [weak self] in

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -2,8 +2,6 @@ import Foundation
 import OSLog
 import SwiftUI
 
-// MARK: - Logging
-
 private let logger = Logger(subsystem: "io.linnane.brewy", category: "BrewService")
 
 @Observable
@@ -110,6 +108,7 @@ final class BrewService {
     @ObservationIgnored var infoCache: [String: String] = [:]
     @ObservationIgnored private var tapHealthTask: Task<Void, Never>?
     @ObservationIgnored var actionCommandTask: Task<CommandResult, Never>?
+    @ObservationIgnored var brewfileSnapshot: BrewfileSnapshot?
     @ObservationIgnored var packageUpdatesStarted = false
     @ObservationIgnored var scheduledAutoRefreshInterval: Int?
     @ObservationIgnored var initialRefreshTask: Task<Void, Never>?
@@ -169,19 +168,14 @@ final class BrewService {
         var reverse: [String: [BrewPackage]] = [:]
         reverse.reserveCapacity(all.count)
         for pkg in all {
-            for dep in pkg.dependencies {
-                reverse[dep, default: []].append(pkg)
+            for dependency in pkg.dependencyReferences {
+                reverse[dependency.id, default: []].append(pkg)
             }
         }
         reverseDependencies = reverse
-        leavesPackages = installedFormulae.filter { reverse[$0.name] == nil || reverse[$0.name]!.isEmpty }
+        leavesPackages = installedFormulae.filter { reverse[$0.id]?.isEmpty ?? true }
         pinnedPackages = all.filter(\.pinned)
     }
-
-    func dependents(of name: String) -> [BrewPackage] {
-        reverseDependencies[name] ?? []
-    }
-
 }
 
 // MARK: - Cache
@@ -207,7 +201,7 @@ extension BrewService {
 
     /// Current schema version for the package cache. Bump when `CachedData` gains a non-optional
     /// field or changes semantics so old caches are deleted rather than silently discarded each launch.
-    static let cacheSchemaVersion = 1
+    static let cacheSchemaVersion = 2
 
     private struct CachedData: Codable {
         let schemaVersion: Int
@@ -460,6 +454,16 @@ extension BrewService {
         return await commandRunner.run(
             arguments,
             brewPath: brewPath,
+            timeout: CommandRunner.timeout(forBrewArguments: arguments)
+        )
+    }
+
+    func runBrewCommand(_ arguments: [String], standardInput: Data) async -> CommandResult {
+        let brewPath = CommandRunner.resolvedBrewPath(preferred: customBrewPath)
+        return await commandRunner.run(
+            arguments,
+            brewPath: brewPath,
+            standardInput: standardInput,
             timeout: CommandRunner.timeout(forBrewArguments: arguments)
         )
     }

--- a/Brewy/Models/BrewfileSnapshot.swift
+++ b/Brewy/Models/BrewfileSnapshot.swift
@@ -1,0 +1,75 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+struct BrewfileSnapshot: Sendable {
+    static let maximumByteCount = 1_048_576
+
+    let sourcePath: String
+    let data: Data
+    let digest: String
+
+    init(sourcePath: String, data: Data) throws {
+        guard data.count <= Self.maximumByteCount else {
+            throw BrewfileSnapshotError.tooLarge
+        }
+        self.sourcePath = sourcePath
+        self.data = data
+        self.digest = SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    static func read(from url: URL) throws -> Self {
+        let path = url.standardizedFileURL.path
+        let descriptor = open(path, O_RDONLY | O_CLOEXEC | O_NONBLOCK)
+        guard descriptor >= 0 else {
+            throw BrewfileSnapshotError.unreadable
+        }
+        defer { close(descriptor) }
+
+        var status = stat()
+        guard fstat(descriptor, &status) == 0,
+              status.st_mode & S_IFMT == S_IFREG else {
+            throw BrewfileSnapshotError.notRegular
+        }
+        guard status.st_size >= 0,
+              status.st_size <= Self.maximumByteCount else {
+            throw BrewfileSnapshotError.tooLarge
+        }
+
+        var contents = Data()
+        contents.reserveCapacity(Int(status.st_size))
+        var buffer = [UInt8](repeating: 0, count: 65_536)
+        while true {
+            let bytesRead = Darwin.read(descriptor, &buffer, buffer.count)
+            if bytesRead == 0 { break }
+            if bytesRead < 0 {
+                if errno == EINTR { continue }
+                throw BrewfileSnapshotError.unreadable
+            }
+            contents.append(contentsOf: buffer.prefix(bytesRead))
+            guard contents.count <= Self.maximumByteCount else {
+                throw BrewfileSnapshotError.tooLarge
+            }
+        }
+        return try Self(sourcePath: path, data: contents)
+    }
+}
+
+enum BrewfileSnapshotError: LocalizedError {
+    case unreadable
+    case notRegular
+    case tooLarge
+
+    var errorDescription: String? {
+        switch self {
+        case .unreadable:
+            "The Brewfile could not be read."
+        case .notRegular:
+            "The Brewfile must be a regular file."
+        case .tooLarge:
+            "The Brewfile exceeds the 1 MB size limit."
+        }
+    }
+}

--- a/Brewy/Models/CommandPipeSupport.swift
+++ b/Brewy/Models/CommandPipeSupport.swift
@@ -1,0 +1,82 @@
+import Darwin
+import Foundation
+
+extension CommandRunner {
+    static func provideStandardInput(_ data: Data?, to pipe: Pipe?) -> String? {
+        guard let data, let pipe else { return nil }
+        let writer = pipe.fileHandleForWriting
+        guard fcntl(writer.fileDescriptor, F_SETNOSIGPIPE, 1) != -1 else {
+            let message = String(cString: strerror(errno))
+            try? writer.close()
+            return "Failed to configure command input: \(message)"
+        }
+        do {
+            try writer.write(contentsOf: data)
+        } catch {
+            try? writer.close()
+            return "Failed to provide command input: \(error.localizedDescription)"
+        }
+        try? writer.close()
+        return nil
+    }
+
+    static func collectOutput(
+        stdoutReader: PipeReader,
+        stderrReader: PipeReader,
+        deadline: DispatchTime
+    ) -> (stdout: String, stderr: String) {
+        let stdoutData = stdoutReader.wait { deadline }
+        let stderrData = stderrReader.wait { deadline }
+        return (
+            decodeOutput(stdoutData),
+            decodeOutput(stderrData)
+        )
+    }
+
+    private static func decodeOutput(_ data: Data) -> String {
+        var decoder = UTF8StreamDecoder()
+        return decoder.decode(data) + decoder.flush()
+    }
+}
+
+final class TimeoutWatchdog: @unchecked Sendable {
+    private let cancellation: DispatchSemaphore
+    private let thread: Thread
+
+    init(deadline: DispatchTime, action: @escaping @Sendable () -> Void) {
+        let cancellation = DispatchSemaphore(value: 0)
+        self.cancellation = cancellation
+        self.thread = Thread {
+            guard cancellation.wait(timeout: deadline) == .timedOut else { return }
+            action()
+        }
+        thread.name = "Brewy command timeout"
+        thread.qualityOfService = .default
+        thread.start()
+    }
+
+    func cancel() {
+        cancellation.signal()
+    }
+}
+
+func drainPipesInParallel(
+    stdout: Pipe,
+    stderr: Pipe,
+    commandDescription: String,
+    onOutput: (@Sendable (String) -> Void)?
+) -> (stdout: PipeReader, stderr: PipeReader) {
+    let stdoutReader = PipeReader(
+        pipe: stdout,
+        label: "\(commandDescription) stdout",
+        onText: onOutput
+    )
+    let stderrReader = PipeReader(
+        pipe: stderr,
+        label: "\(commandDescription) stderr",
+        onText: onOutput
+    )
+    stdoutReader.start()
+    stderrReader.start()
+    return (stdoutReader, stderrReader)
+}

--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -39,6 +39,12 @@ struct CommandResult: Sendable {
 
 protocol CommandRunning: Sendable {
     func run(_ arguments: [String], brewPath: String, timeout: Duration) async -> CommandResult
+    func run(
+        _ arguments: [String],
+        brewPath: String,
+        standardInput: Data,
+        timeout: Duration
+    ) async -> CommandResult
     func runExecutable(_ executablePath: String, arguments: [String], timeout: Duration) async -> CommandResult
     /// Runs the command, delivering output incrementally as it arrives. `onOutput` may be
     /// called from arbitrary threads; the returned result still carries the full output.
@@ -84,6 +90,20 @@ struct DefaultCommandRunner: CommandRunning {
         await CommandRunner.runExecutable(executablePath, arguments: arguments, timeout: timeout)
     }
 
+    func run(
+        _ arguments: [String],
+        brewPath: String,
+        standardInput: Data,
+        timeout: Duration
+    ) async -> CommandResult {
+        await CommandRunner.runExecutable(
+            brewPath,
+            arguments: arguments,
+            standardInput: standardInput,
+            timeout: timeout
+        )
+    }
+
     func runStreaming(
         _ arguments: [String],
         brewPath: String,
@@ -99,6 +119,7 @@ struct DefaultCommandRunner: CommandRunning {
 enum CommandRunner {
 
     static let defaultTimeout: Duration = .seconds(300)
+    static let capturedOutputByteLimit = 16 * 1_024 * 1_024
 
     /// Mutating commands legitimately run far past `defaultTimeout` (large downloads, source
     /// builds, post-install scripts); SIGKILLing them mid-flight can leave a broken keg.
@@ -132,16 +153,6 @@ enum CommandRunner {
         return preferred
     }
 
-    static func resolvedPrivilegedBrewPath(
-        preferred: String,
-        standardPaths: [String] = standardBrewPaths
-    ) -> String? {
-        if FileManager.default.isExecutableFile(atPath: preferred) {
-            return standardBrewPath(matching: preferred, standardPaths: standardPaths)
-        }
-        return standardPaths.first { FileManager.default.isExecutableFile(atPath: $0) }
-    }
-
     static func preventsHomebrewAutoUpdate(userDefaults: UserDefaults = .standard) -> Bool {
         userDefaults.bool(forKey: preventHomebrewAutoUpdateKey)
     }
@@ -157,6 +168,7 @@ enum CommandRunner {
     static func runExecutable(
         _ executablePath: String,
         arguments: [String],
+        standardInput: Data? = nil,
         timeout: Duration = defaultTimeout,
         onOutput: (@Sendable (String) -> Void)? = nil
     ) async -> CommandResult {
@@ -164,14 +176,15 @@ enum CommandRunner {
         let commandDescription = "\(execName) \(arguments.joined(separator: " "))"
         logger.info("Running: \(commandDescription)")
         let startTime = ContinuousClock.now
-        let preventHomebrewAutoUpdate = preventsHomebrewAutoUpdate()
+        let preventHomebrewAutoUpdate = shouldPreventHomebrewAutoUpdate(for: arguments)
 
         let execution = ProcessExecution(
             executablePath: executablePath,
             arguments: arguments,
             timeout: timeout,
             commandDescription: commandDescription,
-            preventHomebrewAutoUpdate: preventHomebrewAutoUpdate
+            preventHomebrewAutoUpdate: preventHomebrewAutoUpdate,
+            standardInput: standardInput
         )
         let handle = ProcessHandle()
         let result = await withTaskCancellationHandler {
@@ -232,15 +245,14 @@ extension CommandRunner {
         return env
     }
 
-    // MARK: - Private
-
-    private static func standardBrewPath(matching path: String, standardPaths: [String]) -> String? {
-        let resolvedPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
-        return standardPaths.first { standardPath in
-            FileManager.default.isExecutableFile(atPath: standardPath)
-                && URL(fileURLWithPath: standardPath).resolvingSymlinksInPath().path == resolvedPath
-        }
+    static func shouldPreventHomebrewAutoUpdate(
+        for arguments: [String],
+        userDefaults: UserDefaults = .standard
+    ) -> Bool {
+        preventsHomebrewAutoUpdate(userDefaults: userDefaults) || arguments.first == "bundle"
     }
+
+    // MARK: - Private
 
     /// Convert a `Duration` into a `DispatchTimeInterval` that preserves sub-second precision.
     private static func dispatchInterval(from duration: Duration) -> DispatchTimeInterval {
@@ -256,6 +268,7 @@ extension CommandRunner {
         let timeout: Duration
         let commandDescription: String
         let preventHomebrewAutoUpdate: Bool
+        let standardInput: Data?
     }
 
     private static func executeProcess(
@@ -271,7 +284,7 @@ extension CommandRunner {
                 standardOutput: ""
             )
         }
-        let (process, stdoutPipe, stderrPipe) = configuredProcess(for: execution)
+        let (process, stdinPipe, stdoutPipe, stderrPipe) = configuredProcess(for: execution)
 
         do {
             try process.run()
@@ -299,28 +312,33 @@ extension CommandRunner {
             after: execution.timeout,
             commandDescription: execution.commandDescription
         )
+        let inputError = provideStandardInput(execution.standardInput, to: stdinPipe)
+        if inputError != nil {
+            handle.terminate()
+        }
 
         process.waitUntilExit()
         handle.processDidExit()
         timeoutWatchdog.cancel()
-        _ = handle.waitForTermination()
-        var drainDeadline: DispatchTime?
-        let requestedDrainDeadline = {
-            if drainDeadline == nil, handle.wasInterrupted {
-                drainDeadline = DispatchTime.now() + dispatchInterval(from: pipeDrainGracePeriod)
-            }
-            return drainDeadline
-        }
-        let out = stdoutData.wait(untilRequested: requestedDrainDeadline)
-        let err = stderrData.wait(untilRequested: requestedDrainDeadline)
-        let stdout = String(data: out, encoding: .utf8) ?? ""
-        let stderr = String(data: err, encoding: .utf8) ?? ""
-        return commandResult(
+        let terminationSucceeded = handle.waitForTermination()
+        let drainDeadline = DispatchTime.now() + dispatchInterval(from: pipeDrainGracePeriod)
+        let output = collectOutput(
+            stdoutReader: stdoutData,
+            stderrReader: stderrData,
+            deadline: drainDeadline
+        )
+        let result = commandResult(
             process: process,
             execution: execution,
             handle: handle,
-            stdout: stdout,
-            stderr: stderr
+            stdout: output.stdout,
+            stderr: output.stderr
+        )
+        guard let inputError else { return result }
+        return inputFailureResult(
+            inputError,
+            processResult: result,
+            terminationSucceeded: terminationSucceeded
         )
     }
 
@@ -370,8 +388,9 @@ extension CommandRunner {
         )
     }
 
-    private static func configuredProcess(for execution: ProcessExecution) -> (Process, Pipe, Pipe) {
+    private static func configuredProcess(for execution: ProcessExecution) -> (Process, Pipe?, Pipe, Pipe) {
         let process = Process()
+        let stdinPipe = execution.standardInput == nil ? nil : Pipe()
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
         process.executableURL = URL(fileURLWithPath: execution.executablePath)
@@ -380,9 +399,10 @@ extension CommandRunner {
             brewPath: execution.executablePath,
             preventHomebrewAutoUpdate: execution.preventHomebrewAutoUpdate
         )
+        process.standardInput = stdinPipe
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
-        return (process, stdoutPipe, stderrPipe)
+        return (process, stdinPipe, stdoutPipe, stderrPipe)
     }
 
     private static func commandOutput(stdout: String, stderr: String, terminationStatus: Int32) -> String {
@@ -439,6 +459,21 @@ extension CommandRunner {
         return "\(message)\nSome child processes may still be running."
     }
 
+    static func inputFailureResult(
+        _ message: String,
+        processResult: CommandResult,
+        terminationSucceeded: Bool
+    ) -> CommandResult {
+        CommandResult(
+            output: terminationOutput(message, succeeded: terminationSucceeded),
+            success: false,
+            cancelled: processResult.cancelled,
+            standardOutput: processResult.standardOutput,
+            standardError: message,
+            exitCode: processResult.exitCode
+        )
+    }
+
     private static func scheduleTimeout(
         handle: ProcessHandle,
         after timeout: Duration,
@@ -449,46 +484,4 @@ extension CommandRunner {
             logger.warning("Timeout exceeded, sending SIGTERM: \(commandDescription)")
         }
     }
-}
-
-final class TimeoutWatchdog: @unchecked Sendable {
-    private let cancellation: DispatchSemaphore
-    private let thread: Thread
-
-    init(deadline: DispatchTime, action: @escaping @Sendable () -> Void) {
-        let cancellation = DispatchSemaphore(value: 0)
-        self.cancellation = cancellation
-        self.thread = Thread {
-            guard cancellation.wait(timeout: deadline) == .timedOut else { return }
-            action()
-        }
-        thread.name = "Brewy command timeout"
-        thread.qualityOfService = .default
-        thread.start()
-    }
-
-    func cancel() {
-        cancellation.signal()
-    }
-}
-
-private func drainPipesInParallel(
-    stdout: Pipe,
-    stderr: Pipe,
-    commandDescription: String,
-    onOutput: (@Sendable (String) -> Void)?
-) -> (stdout: PipeReader, stderr: PipeReader) {
-    let stdoutReader = PipeReader(
-        pipe: stdout,
-        label: "\(commandDescription) stdout",
-        onText: onOutput
-    )
-    let stderrReader = PipeReader(
-        pipe: stderr,
-        label: "\(commandDescription) stderr",
-        onText: onOutput
-    )
-    stdoutReader.start()
-    stderrReader.start()
-    return (stdoutReader, stderrReader)
 }

--- a/Brewy/Models/PackageModel.swift
+++ b/Brewy/Models/PackageModel.swift
@@ -2,10 +2,17 @@ import Foundation
 
 // MARK: - Package Source
 
-enum PackageSource: String, Codable {
+enum PackageSource: String, Codable, Sendable {
     case formula
     case cask
     case mas
+}
+
+struct PackageReference: Identifiable, Hashable, Codable, Sendable {
+    let name: String
+    let source: PackageSource
+
+    var id: String { "\(source.rawValue)-\(name)" }
 }
 
 struct BrewPackage: Identifiable, Hashable, Codable {
@@ -22,7 +29,9 @@ struct BrewPackage: Identifiable, Hashable, Codable {
     let source: PackageSource
     let pinned: Bool
     let installedOnRequest: Bool
-    let dependencies: [String]
+    let dependencyReferences: [PackageReference]
+
+    var dependencies: [String] { dependencyReferences.map(\.name) }
 
     var isFormula: Bool { source == .formula }
     var isCask: Bool { source == .cask }
@@ -49,6 +58,7 @@ struct BrewPackage: Identifiable, Hashable, Codable {
         pinned: Bool,
         installedOnRequest: Bool,
         dependencies: [String],
+        dependencyReferences: [PackageReference]? = nil,
         repositoryURL: String? = nil
     ) {
         self.id = id
@@ -64,7 +74,8 @@ struct BrewPackage: Identifiable, Hashable, Codable {
         self.source = source
         self.pinned = pinned
         self.installedOnRequest = installedOnRequest
-        self.dependencies = dependencies
+        self.dependencyReferences = dependencyReferences
+            ?? dependencies.map { PackageReference(name: $0, source: .formula) }
     }
 
     static func == (lhs: Self, rhs: Self) -> Bool {
@@ -84,6 +95,7 @@ struct BrewPackage: Identifiable, Hashable, Codable {
 struct DependencyTreeNode: Identifiable, Hashable {
     let id: String
     let name: String
+    let packageID: String?
     let isInstalled: Bool
     let installedOnRequest: Bool
     /// True if walking further would re-enter an ancestor in the same chain.
@@ -191,10 +203,6 @@ struct ActionHistoryEntry: Identifiable, Codable, Hashable {
         "brew " + arguments.joined(separator: " ")
     }
 
-    var isRetryable: Bool {
-        status == .failure && !arguments.isEmpty
-    }
-
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id
     }
@@ -206,7 +214,7 @@ struct ActionHistoryEntry: Identifiable, Codable, Hashable {
 
 // MARK: - Appcast Release
 
-struct AppcastRelease: Identifiable {
+struct AppcastRelease: Identifiable, Sendable {
     let title: String
     let pubDate: String?
     let version: String?
@@ -224,81 +232,6 @@ struct AppcastRelease: Identifiable {
     var publishedDate: Date? {
         guard let pubDate else { return nil }
         return Self.pubDateFormatter.date(from: pubDate)
-    }
-}
-
-// MARK: - Appcast Parser
-
-final class AppcastParser: NSObject, XMLParserDelegate {
-    private var currentElement = ""
-    private var currentTitle = ""
-    private var currentPubDate = ""
-    private var currentVersion = ""
-    private var currentDescription = ""
-    private var release: AppcastRelease?
-    private var insideItem = false
-
-    func parse(data: Data) -> AppcastRelease? {
-        currentElement = ""
-        currentTitle = ""
-        currentPubDate = ""
-        currentVersion = ""
-        currentDescription = ""
-        release = nil
-        insideItem = false
-
-        let parser = XMLParser(data: data)
-        parser.delegate = self
-        parser.parse()
-        return release
-    }
-
-    func parser(_ parser: XMLParser, didStartElement elementName: String,
-                namespaceURI: String?, qualifiedName: String?,
-                attributes: [String: String] = [:]) {
-        currentElement = elementName
-        if elementName == "item" {
-            insideItem = true
-            currentTitle = ""
-            currentPubDate = ""
-            currentVersion = ""
-            currentDescription = ""
-        }
-    }
-
-    func parser(_ parser: XMLParser, foundCharacters string: String) {
-        guard insideItem else { return }
-        switch currentElement {
-        case "title": currentTitle += string
-        case "pubDate": currentPubDate += string
-        case "sparkle:shortVersionString": currentVersion += string
-        case "description": currentDescription += string
-        default: break
-        }
-    }
-
-    func parser(_ parser: XMLParser, foundCDATA CDATABlock: Data) {
-        guard insideItem, currentElement == "description" else { return }
-        if let text = String(data: CDATABlock, encoding: .utf8) {
-            currentDescription += text
-        }
-    }
-
-    func parser(_ parser: XMLParser, didEndElement elementName: String,
-                namespaceURI: String?, qualifiedName: String?) {
-        if elementName == "item" {
-            // Keep the first item; Sparkle feeds list newest first, so ignore older entries.
-            if release == nil {
-                release = AppcastRelease(
-                    title: currentTitle.trimmingCharacters(in: .whitespacesAndNewlines),
-                    pubDate: currentPubDate.trimmingCharacters(in: .whitespacesAndNewlines),
-                    version: currentVersion.trimmingCharacters(in: .whitespacesAndNewlines),
-                    descriptionHTML: currentDescription.isEmpty ? nil : currentDescription
-                )
-            }
-            insideItem = false
-        }
-        currentElement = ""
     }
 }
 

--- a/Brewy/Models/PipeReader.swift
+++ b/Brewy/Models/PipeReader.swift
@@ -8,19 +8,36 @@ private let logger = Logger(subsystem: "io.linnane.brewy", category: "PipeReader
 /// Thread-safe accumulator for data chunks.
 final class LockedData: Sendable {
     private let lock = NSLock()
-    nonisolated(unsafe) private var chunks: [Data] = []
+    private let maximumByteCount: Int
+    nonisolated(unsafe) private var contents = Data()
+    nonisolated(unsafe) private var wasTruncated = false
+
+    init(maximumByteCount: Int) {
+        self.maximumByteCount = max(0, maximumByteCount)
+        contents.reserveCapacity(min(self.maximumByteCount, 65_536))
+    }
 
     func append(_ data: Data) {
         lock.lock()
-        chunks.append(data)
+        let remaining = max(0, maximumByteCount - contents.count)
+        if remaining > 0 {
+            contents.append(data.prefix(remaining))
+        }
+        if data.count > remaining {
+            wasTruncated = true
+        }
         lock.unlock()
     }
 
     func combined() -> Data {
         lock.lock()
-        var result = Data()
-        result.reserveCapacity(chunks.reduce(0) { $0 + $1.count })
-        for chunk in chunks { result.append(chunk) }
+        var result = contents
+        if wasTruncated {
+            let marker = Data("\n… [output truncated]\n".utf8)
+            let contentLimit = max(0, maximumByteCount - marker.count)
+            result = Data(contents.prefix(contentLimit))
+            result.append(marker.prefix(maximumByteCount - result.count))
+        }
         lock.unlock()
         return result
     }
@@ -34,7 +51,7 @@ final class PipeReader: @unchecked Sendable {
     private let fileHandle: FileHandle
     private let label: String
     private let onText: (@Sendable (String) -> Void)?
-    private let accumulator = LockedData()
+    private let accumulator: LockedData
     private let semaphore = DispatchSemaphore(value: 0)
     private let lock = NSLock()
     private var decoder = UTF8StreamDecoder()
@@ -43,10 +60,16 @@ final class PipeReader: @unchecked Sendable {
     private var byteCount = 0
     private var isFinished = false
 
-    init(pipe: Pipe, label: String = "pipe", onText: (@Sendable (String) -> Void)? = nil) {
+    init(
+        pipe: Pipe,
+        label: String = "pipe",
+        maximumByteCount: Int = CommandRunner.capturedOutputByteLimit,
+        onText: (@Sendable (String) -> Void)? = nil
+    ) {
         self.fileHandle = pipe.fileHandleForReading
         self.label = label
         self.onText = onText
+        self.accumulator = LockedData(maximumByteCount: maximumByteCount)
     }
 
     func start() {

--- a/Brewy/Models/ProcessTermination.swift
+++ b/Brewy/Models/ProcessTermination.swift
@@ -289,6 +289,16 @@ final class ProcessHandle: @unchecked Sendable {
         lock.unlock()
     }
 
+    func terminate() {
+        lock.lock()
+        guard !finished, !processExited else {
+            lock.unlock()
+            return
+        }
+        termination?.start()
+        lock.unlock()
+    }
+
     func processDidExit() {
         lock.lock()
         processExited = true

--- a/Brewy/Models/ServicesService.swift
+++ b/Brewy/Models/ServicesService.swift
@@ -8,13 +8,31 @@ private let logger = Logger(subsystem: "io.linnane.brewy", category: "ServicesSe
 enum ServicesParser {
 
     static func parseJSON(_ output: String) -> [BrewServiceItem] {
+        (try? decodeJSON(output)) ?? []
+    }
+
+    static func decodeJSON(_ output: String) throws -> [BrewServiceItem] {
         guard let data = output.data(using: .utf8) else { return [] }
         do {
             return try JSONDecoder().decode([BrewServiceItem].self, from: data)
         } catch {
             logger.error("Failed to parse services JSON: \(error.localizedDescription)")
-            return []
+            throw error
         }
+    }
+}
+
+struct ServicesFetchError: LocalizedError {
+    let commandOutput: String
+
+    var errorDescription: String? {
+        let output = UTF8ByteTruncation.prefix(
+            commandOutput.trimmingCharacters(in: .whitespacesAndNewlines),
+            maxBytes: 4_096
+        )
+        return output.isEmpty
+            ? "Homebrew did not return valid service data."
+            : "Homebrew could not load services.\n\(output)"
     }
 }
 
@@ -22,33 +40,43 @@ enum ServicesParser {
 
 extension BrewService {
 
-    func fetchServices() async -> [BrewServiceItem] {
+    func fetchServices() async throws -> [BrewServiceItem] {
         let brewPath = CommandRunner.resolvedBrewPath(preferred: customBrewPath)
 
         let infoResult = await commandRunner.run(["services", "info", "--all", "--json"], brewPath: brewPath)
+        let infoServices: [BrewServiceItem]?
         if infoResult.success {
-            let services = ServicesParser.parseJSON(infoResult.output)
-            if !services.isEmpty { return services }
+            infoServices = try? ServicesParser.decodeJSON(infoResult.output)
+            if let infoServices, !infoServices.isEmpty { return infoServices }
+        } else {
+            infoServices = nil
         }
 
         let listResult = await commandRunner.run(["services", "list", "--json"], brewPath: brewPath)
         guard listResult.success else {
-            logger.warning("Failed to fetch services: \(listResult.output.prefix(200))")
-            return []
+            if let infoServices { return infoServices }
+            let output = listResult.output.isEmpty ? infoResult.output : listResult.output
+            logger.warning("Failed to fetch services: \(output.prefix(200))")
+            throw ServicesFetchError(commandOutput: output)
         }
-        return ServicesParser.parseJSON(listResult.output)
+        do {
+            return try ServicesParser.decodeJSON(listResult.output)
+        } catch {
+            logger.warning("Homebrew returned invalid services JSON: \(error.localizedDescription)")
+            throw ServicesFetchError(commandOutput: "Homebrew returned invalid service data.")
+        }
     }
 
-    func startService(_ name: String, asSudo: Bool = false) async -> CommandResult {
-        await runServiceCommand(["services", "start", name], asSudo: asSudo)
+    func startService(_ name: String) async -> CommandResult {
+        await runServiceCommand(["services", "start", name])
     }
 
-    func stopService(_ name: String, asSudo: Bool = false) async -> CommandResult {
-        await runServiceCommand(["services", "stop", name], asSudo: asSudo)
+    func stopService(_ name: String) async -> CommandResult {
+        await runServiceCommand(["services", "stop", name])
     }
 
-    func restartService(_ name: String, asSudo: Bool = false) async -> CommandResult {
-        await runServiceCommand(["services", "restart", name], asSudo: asSudo)
+    func restartService(_ name: String) async -> CommandResult {
+        await runServiceCommand(["services", "restart", name])
     }
 
     func cleanupServices() async -> CommandResult {
@@ -60,30 +88,7 @@ extension BrewService {
         return result
     }
 
-    private func runServiceCommand(_ arguments: [String], asSudo: Bool) async -> CommandResult {
-        if asSudo {
-            guard let brewPath = CommandRunner.resolvedPrivilegedBrewPath(preferred: customBrewPath) else {
-                return CommandResult(
-                    output: "Run as root requires Homebrew at /opt/homebrew/bin/brew or /usr/local/bin/brew.",
-                    success: false
-                )
-            }
-            // Run brew as root via the native admin auth dialog. Args pass through osascript's argv
-            // and are shell-quoted with `quoted form of`, so nothing is interpolated into the script.
-            let script = """
-            on run argv
-                set cmd to ""
-                repeat with arg in argv
-                    set cmd to cmd & quoted form of (arg as text) & " "
-                end repeat
-                do shell script cmd with administrator privileges
-            end run
-            """
-            return await commandRunner.runExecutable(
-                "/usr/bin/osascript",
-                arguments: ["-e", script, brewPath] + arguments
-            )
-        }
+    private func runServiceCommand(_ arguments: [String]) async -> CommandResult {
         let brewPath = CommandRunner.resolvedBrewPath(preferred: customBrewPath)
         return await commandRunner.run(arguments, brewPath: brewPath)
     }

--- a/Brewy/Models/UITestFixtures.swift
+++ b/Brewy/Models/UITestFixtures.swift
@@ -89,6 +89,15 @@ final class UITestCommandRunner: CommandRunning, @unchecked Sendable {
         return CommandResult(output: "Fixture command completed.\n", success: true)
     }
 
+    func run(
+        _ arguments: [String],
+        brewPath: String,
+        standardInput: Data,
+        timeout: Duration
+    ) async -> CommandResult {
+        await run(arguments, brewPath: brewPath, timeout: timeout)
+    }
+
     private func analyticsResult(_ arguments: [String]) -> CommandResult? {
         switch arguments {
         case ["analytics", "state"]:
@@ -464,7 +473,19 @@ extension BrewService {
     }
 
     private func loadUITestBundle() {
-        brewfileURL = resolveBrewfile()
+        let brewfileURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "BrewyUITest-\(ProcessInfo.processInfo.processIdentifier)-Brewfile"
+        )
+        let data = Data("brew \"ripgrep\"\nbrew \"jq\"\ncask \"firefox\"\n".utf8)
+        do {
+            try data.write(to: brewfileURL, options: .atomic)
+        } catch {
+            bundleEntries = []
+            bundleCheckStatus = .failed("Unable to create the UI test Brewfile.")
+            return
+        }
+        customBrewfilePath = brewfileURL.path
+        guard trustBrewfile(at: brewfileURL), resolveBrewfile() != nil else { return }
         bundleEntries = [
             BrewBundleEntry(type: .formula, name: "ripgrep", status: .installed),
             BrewBundleEntry(type: .formula, name: "jq", status: .missing),

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -87,7 +87,7 @@ struct ContentView: View {
         } detail: {
             detailView
         }
-        .environment(\.selectPackage) { name in navigateToPackage(name) }
+        .environment(\.selectPackage) { packageID in navigateToPackage(packageID) }
         .overlay {
             if brewService.isPerformingAction {
                 ZStack {
@@ -220,8 +220,8 @@ struct ContentView: View {
         }
     }
 
-    private func navigateToPackage(_ name: String) {
-        if let match = brewService.allInstalled.first(where: { $0.name == name }) {
+    private func navigateToPackage(_ packageID: String) {
+        if let match = brewService.allInstalled.first(where: { $0.id == packageID }) {
             let destination: SidebarCategory = switch match.source {
             case .formula: .formulae
             case .cask: .casks

--- a/Brewy/Views/DependencyTreeView.swift
+++ b/Brewy/Views/DependencyTreeView.swift
@@ -11,8 +11,8 @@ struct DependencyTreeSection: View {
     @State private var pullsInExpanded = false
 
     var body: some View {
-        let reverse = brewService.reverseDependencyTree(for: package.name)
-        let forward = brewService.forwardDependencyTree(for: package.name)
+        let reverse = brewService.reverseDependencyTree(for: package)
+        let forward = brewService.forwardDependencyTree(for: package)
 
         Group {
             if !reverse.isEmpty || !forward.isEmpty {
@@ -102,7 +102,7 @@ private struct DependencyTreeRow: View {
     var body: some View {
         HStack(spacing: 6) {
             Button {
-                if node.isInstalled { selectPackage(node.name) }
+                if let packageID = node.packageID { selectPackage(packageID) }
             } label: {
                 Text(node.name)
                     .font(.system(.callout, design: .monospaced))

--- a/Brewy/Views/GroupsView.swift
+++ b/Brewy/Views/GroupsView.swift
@@ -138,6 +138,8 @@ private struct CreateGroupSheet: View {
                                 )
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel("Use \(icon) icon")
+                        .accessibilityAddTraits(selectedIcon == icon ? .isSelected : [])
                     }
                 }
             }
@@ -242,7 +244,7 @@ struct GroupDetailView: View {
             Section("Packages") {
                 ForEach(groupPackages) { package in
                     GroupPackageRow(package: package) {
-                        selectPackage(package.name)
+                        selectPackage(package.id)
                     } onRemove: {
                         brewService.removeFromGroup(group, packageID: package.id)
                     }
@@ -298,6 +300,7 @@ private struct GroupPackageRow: View {
             }
             .buttonStyle(.plain)
             .help("Go to \(package.name)")
+            .accessibilityLabel("Go to \(package.name)")
         }
         .contextMenu {
             Button("Go to Package", systemImage: "arrow.right.circle") {
@@ -361,6 +364,8 @@ private struct EditGroupSheet: View {
                                 )
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel("Use \(icon) icon")
+                        .accessibilityAddTraits(selectedIcon == icon ? .isSelected : [])
                     }
                 }
             }

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -298,7 +298,7 @@ private struct PackageInfoSection: View {
             }
 
             if !package.dependencies.isEmpty {
-                DependencyTags(label: "Dependencies", packages: package.dependencies)
+                DependencyTags(label: "Dependencies", packages: package.dependencyReferences)
             }
         }
         .padding(.horizontal)
@@ -332,21 +332,21 @@ private struct DependencyTags: View {
     @Environment(BrewService.self)
     private var brewService
     let label: String
-    let packages: [String]
+    let packages: [PackageReference]
 
     var body: some View {
-        let knownNames = brewService.installedNames
+        let knownIDs = brewService.installedIDs
         VStack(alignment: .leading, spacing: 4) {
             Text(label)
                 .font(.caption)
                 .foregroundStyle(.secondary)
             FlowLayout(spacing: 6) {
-                ForEach(packages, id: \.self) { name in
-                    let isInstalled = knownNames.contains(name)
+                ForEach(packages) { package in
+                    let isInstalled = knownIDs.contains(package.id)
                     Button {
-                        selectPackage(name)
+                        selectPackage(package.id)
                     } label: {
-                        Text(name)
+                        Text(package.name)
                             .font(.system(.caption, design: .monospaced))
                             .padding(.horizontal, 8)
                             .padding(.vertical, 4)
@@ -356,7 +356,7 @@ private struct DependencyTags: View {
                     .buttonStyle(.plain)
                     .disabled(!isInstalled)
                     .opacity(isInstalled ? 1 : 0.5)
-                    .help(isInstalled ? "Go to \(name)" : "\(name) (not installed)")
+                    .help(isInstalled ? "Go to \(package.name)" : "\(package.name) (not installed)")
                 }
             }
         }

--- a/Brewy/Views/ReleaseNotesHTML.swift
+++ b/Brewy/Views/ReleaseNotesHTML.swift
@@ -1,14 +1,21 @@
 import SwiftUI
 
 enum ReleaseNotesHTML {
-    private static let blockedTagPattern = [
-        #"<\s*(script|style|iframe|object|embed|img|source|"#,
-        #"video|audio|link|meta|base)\b[^>]*(?:>.*?<\s*/\s*\1\s*>|/?>)"#
-    ].joined()
+    static let maximumHTMLByteCount = AppcastParser.maximumDescriptionByteCount
+    private static let allowedTags: Set<String> = [
+        "a", "b", "blockquote", "br", "code", "em", "h1", "h2", "h3", "h4", "h5", "h6",
+        "hr", "i", "li", "ol", "p", "pre", "strong", "ul"
+    ]
+    private static let hrefRegex = try? NSRegularExpression(
+        pattern: #"(?i)(?:^|\s)href\s*=\s*(?:\"([^\"]*)\"|'([^']*)'|([^\s\"'=<>`]+))"#
+    )
 
+    @MainActor
     static func attributedString(from html: String) -> AttributedString? {
+        guard html.utf8.count <= maximumHTMLByteCount else { return nil }
         let safeHTML = stripUnsafeMarkup(from: html)
-        guard let data = safeHTML.data(using: .utf8),
+        guard safeHTML.utf8.count <= maximumHTMLByteCount,
+              let data = safeHTML.data(using: .utf8),
               let nsAttr = try? NSAttributedString(
                 data: data,
                 options: [
@@ -32,20 +39,84 @@ enum ReleaseNotesHTML {
     }
 
     static func stripUnsafeMarkup(from html: String) -> String {
-        guard let regex = try? NSRegularExpression(
-            pattern: blockedTagPattern,
-            options: [.caseInsensitive, .dotMatchesLineSeparators]
-        ) else { return html }
-        // Re-run until stable: removing one tag can re-form another
-        // (e.g. "<<img>img src=x>" collapses to "<img src=x>"), so a single
-        // pass leaks. Each pass strips at least one character, so this ends.
-        var current = html
-        while true {
-            let fullRange = NSRange(current.startIndex..., in: current)
-            let stripped = regex.stringByReplacingMatches(in: current, range: fullRange, withTemplate: "")
-            if stripped == current { return current }
-            current = stripped
+        guard html.utf8.count <= maximumHTMLByteCount else { return "" }
+
+        var result = ""
+        result.reserveCapacity(html.utf8.count)
+        var cursor = html.startIndex
+
+        while cursor < html.endIndex {
+            guard html[cursor] == "<" else {
+                result.append(html[cursor])
+                cursor = html.index(after: cursor)
+                continue
+            }
+
+            let start = cursor
+            var scan = html.index(after: cursor)
+            var depth = 1
+            var isNested = false
+            while scan < html.endIndex, depth > 0 {
+                switch html[scan] {
+                case "<":
+                    depth += 1
+                    isNested = true
+                case ">":
+                    depth -= 1
+                default:
+                    break
+                }
+                scan = html.index(after: scan)
+            }
+
+            guard depth == 0 else {
+                result += " "
+                break
+            }
+            result += isNested ? " " : sanitizedTag(html[start..<scan])
+            cursor = scan
         }
+        return result.utf8.count <= maximumHTMLByteCount ? result : ""
+    }
+
+    private static func sanitizedTag(_ rawTag: Substring) -> String {
+        var content = rawTag.dropFirst().dropLast()
+        while content.first?.isWhitespace == true { content = content.dropFirst() }
+        let isClosing = content.first == "/"
+        if isClosing {
+            content = content.dropFirst()
+            while content.first?.isWhitespace == true { content = content.dropFirst() }
+        }
+
+        let name = String(content.prefix { $0.isLetter || $0.isNumber }).lowercased()
+        guard allowedTags.contains(name) else { return " " }
+        if isClosing { return "</\(name)>" }
+        guard name == "a", let href = hrefValue(in: String(content)),
+              let url = ExternalURLPolicy.url(from: href) else {
+            return "<\(name)>"
+        }
+        return #"<a href="\#(escapedAttribute(url.absoluteString))">"#
+    }
+
+    private static func hrefValue(in tagContent: String) -> String? {
+        guard let hrefRegex,
+              let match = hrefRegex.firstMatch(
+                  in: tagContent,
+                  range: NSRange(tagContent.startIndex..., in: tagContent)
+              ) else { return nil }
+        for index in 1..<match.numberOfRanges where match.range(at: index).location != NSNotFound {
+            guard let range = Range(match.range(at: index), in: tagContent) else { continue }
+            return String(tagContent[range])
+        }
+        return nil
+    }
+
+    private static func escapedAttribute(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
     }
 
     private static func safeLink(from value: Any?) -> URL? {

--- a/Brewy/Views/ServicesView.swift
+++ b/Brewy/Views/ServicesView.swift
@@ -5,6 +5,7 @@ struct ServicesView: View {
     private var brewService
     @State private var services: [BrewServiceItem] = []
     @State private var isLoading = true
+    @State private var loadErrorMessage: String?
     @State private var errorMessage: String?
     @State private var showCleanupConfirmation = false
     @Binding var selectedService: BrewServiceItem?
@@ -12,6 +13,20 @@ struct ServicesView: View {
 
     var body: some View {
         List(selection: $selectedService) {
+            if let loadErrorMessage, !services.isEmpty {
+                Section {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("Unable to Refresh Services", systemImage: "exclamationmark.triangle")
+                            .font(.headline)
+                        Text(loadErrorMessage)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                        Button("Retry") { Task { await loadServices() } }
+                            .disabled(isLoading)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
             ForEach(services) { service in
                 ServiceRow(service: service)
                     .tag(service)
@@ -20,6 +35,14 @@ struct ServicesView: View {
         .overlay {
             if isLoading && services.isEmpty {
                 ProgressView("Loading services…")
+            } else if let loadErrorMessage, services.isEmpty {
+                ContentUnavailableView {
+                    Label("Unable to Load Services", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(loadErrorMessage)
+                } actions: {
+                    Button("Retry") { Task { await loadServices() } }
+                }
             } else if !isLoading && services.isEmpty {
                 ContentUnavailableView(
                     "No Services",
@@ -70,16 +93,19 @@ struct ServicesView: View {
 
     func loadServices() async {
         isLoading = true
-        let fetched = await brewService.fetchServices()
-        guard !Task.isCancelled else {
-            isLoading = false
-            return
+        defer { isLoading = false }
+        do {
+            let fetched = try await brewService.fetchServices()
+            guard !Task.isCancelled else { return }
+            services = fetched
+            loadErrorMessage = nil
+            if let selected = selectedService {
+                selectedService = fetched.first { $0.id == selected.id }
+            }
+        } catch {
+            guard !Task.isCancelled else { return }
+            loadErrorMessage = error.localizedDescription
         }
-        services = fetched
-        if let selected = selectedService {
-            selectedService = fetched.first { $0.id == selected.id }
-        }
-        isLoading = false
     }
 
     private func cleanupServices() async {
@@ -172,7 +198,6 @@ struct ServiceDetailView: View {
     @State private var isPerformingAction = false
     @State private var actionOutput: String?
     @State private var errorMessage: String?
-    @State private var useSudo = false
 
     var body: some View {
         Form {
@@ -254,27 +279,24 @@ struct ServiceDetailView: View {
 
     private var actionsSection: some View {
         Section {
-            Toggle("Run as root (sudo)", isOn: $useSudo)
-                .font(.callout)
-
             HStack(spacing: 12) {
                 if service.running || service.status == "started" {
                     Button {
-                        Task { await performAction { await brewService.stopService(service.name, asSudo: useSudo) } }
+                        Task { await performAction { await brewService.stopService(service.name) } }
                     } label: {
                         Label("Stop", systemImage: "stop.fill")
                     }
                     .tint(.red)
 
                     Button {
-                        Task { await performAction { await brewService.restartService(service.name, asSudo: useSudo) } }
+                        Task { await performAction { await brewService.restartService(service.name) } }
                     } label: {
                         Label("Restart", systemImage: "arrow.clockwise")
                     }
                     .tint(Color.brewyAccent)
                 } else {
                     Button {
-                        Task { await performAction { await brewService.startService(service.name, asSudo: useSudo) } }
+                        Task { await performAction { await brewService.startService(service.name) } }
                     } label: {
                         Label("Start", systemImage: "play.fill")
                     }

--- a/Brewy/Views/WhatsNewView.swift
+++ b/Brewy/Views/WhatsNewView.swift
@@ -1,5 +1,47 @@
 import SwiftUI
 
+enum ReleaseNotesFeed {
+    enum FeedError: LocalizedError {
+        case responseTooLarge
+
+        var errorDescription: String? {
+            "The release-notes feed is larger than Brewy accepts."
+        }
+    }
+
+    static func load(from url: URL, session: URLSession = .shared) async throws -> (Data, HTTPURLResponse) {
+        let (bytes, response) = try await session.bytes(from: url)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        if httpResponse.expectedContentLength > AppcastParser.maximumFeedByteCount {
+            throw FeedError.responseTooLarge
+        }
+
+        var data = Data()
+        data.reserveCapacity(min(Int(max(0, httpResponse.expectedContentLength)), AppcastParser.maximumFeedByteCount))
+        for try await byte in bytes {
+            guard data.count < AppcastParser.maximumFeedByteCount else {
+                throw FeedError.responseTooLarge
+            }
+            data.append(byte)
+        }
+        return (data, httpResponse)
+    }
+
+    @MainActor
+    static func parseAndRender(_ data: Data) async -> (AppcastRelease?, AttributedString?) {
+        let release = await Task.detached(priority: .userInitiated) {
+            AppcastParser().parse(data: data)
+        }.value
+        guard !Task.isCancelled else { return (nil, nil) }
+        let notes = release?.descriptionHTML.flatMap {
+            ReleaseNotesHTML.attributedString(from: $0)
+        }
+        return (release, notes)
+    }
+}
+
 struct WhatsNewView: View {
     @Environment(\.dismiss)
     private var dismiss
@@ -106,24 +148,19 @@ struct WhatsNewView: View {
         }
 
         do {
-            let (data, response) = try await URLSession.shared.data(from: url)
+            let (data, response) = try await ReleaseNotesFeed.load(from: url)
 
-            guard let httpResponse = response as? HTTPURLResponse,
-                  (200...299).contains(httpResponse.statusCode) else {
+            guard (200...299).contains(response.statusCode) else {
                 errorMessage = "Failed to load release notes.\nPlease check your internet connection."
                 isLoading = false
                 return
             }
 
-            let parser = AppcastParser()
-            let loaded = parser.parse(data: data)
+            let parsed = await ReleaseNotesFeed.parseAndRender(data)
             guard !Task.isCancelled else { return }
-            release = loaded
-
-            if let html = loaded?.descriptionHTML {
-                parsedNotes = ReleaseNotesHTML.attributedString(from: html)
-            }
-            if loaded == nil {
+            release = parsed.0
+            parsedNotes = parsed.1
+            if parsed.0 == nil {
                 errorMessage = "No release notes found."
             }
             isLoading = false

--- a/BrewyTests/ActionStreamingTests.swift
+++ b/BrewyTests/ActionStreamingTests.swift
@@ -46,6 +46,15 @@ private final class StreamingMockRunner: CommandRunning, @unchecked Sendable {
         }
     }
 
+    func run(
+        _ arguments: [String],
+        brewPath: String,
+        standardInput: Data,
+        timeout: Duration
+    ) async -> CommandResult {
+        await run(arguments, brewPath: brewPath, timeout: timeout)
+    }
+
     func runExecutable(_ executablePath: String, arguments: [String], timeout: Duration) async -> CommandResult {
         finalResult
     }

--- a/BrewyTests/BrewBundleTests.swift
+++ b/BrewyTests/BrewBundleTests.swift
@@ -211,7 +211,7 @@ struct BrewServiceBundleTests {
         service.customBrewfilePath = brewfile.path
         #expect(service.trustBrewfile(at: brewfile))
         mock.setResult(
-            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            for: ["bundle", "check", "--verbose", "--file=-"],
             output: "The Brewfile's dependencies are satisfied.\n"
         )
 
@@ -230,7 +230,7 @@ struct BrewServiceBundleTests {
         service.customBrewfilePath = brewfile.path
         #expect(service.trustBrewfile(at: brewfile))
         mock.setResult(
-            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            for: ["bundle", "check", "--verbose", "--file=-"],
             output: """
             brew bundle can't satisfy your Brewfile's dependencies.
             → Cask firefox needs to be installed or updated.
@@ -255,7 +255,7 @@ struct BrewServiceBundleTests {
         service.customBrewfilePath = brewfile.path
         #expect(service.trustBrewfile(at: brewfile))
         mock.setResult(
-            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            for: ["bundle", "check", "--verbose", "--file=-"],
             output: "Error: Permission denied @ rb_sysopen - \(brewfile.path)\n",
             success: false
         )
@@ -293,7 +293,7 @@ struct BrewServiceBundleTests {
         service.customBrewfilePath = brewfile.path
         Self.setBundleListResults(mock, path: brewfile.path)
         mock.setResult(
-            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            for: ["bundle", "check", "--verbose", "--file=-"],
             output: "The Brewfile's dependencies are satisfied.\n"
         )
 
@@ -301,33 +301,6 @@ struct BrewServiceBundleTests {
 
         #expect(service.brewfileURL?.path == brewfile.path)
         #expect(service.bundleEntries.isEmpty)
-        #expect(service.bundleCheckStatus == .untrusted)
-        #expect(mock.executedCommands.isEmpty)
-    }
-
-    @Test("changed or switched trusted Brewfile requires trust again")
-    func changedOrSwitchedTrustedBrewfileRequiresTrustAgain() async throws {
-        let brewfile = try Self.makeBrewfile(contents: "brew \"wget\"\n")
-        let otherBrewfile = try Self.makeBrewfile(contents: "brew \"curl\"\n")
-        let mock = MockCommandRunner()
-        let (service, _) = makeService(mock: mock)
-        service.customBrewfilePath = brewfile.path
-        #expect(service.trustBrewfile(at: brewfile))
-        try "brew \"curl\"\n".write(to: brewfile, atomically: true, encoding: .utf8)
-        Self.setBundleListResults(mock, path: brewfile.path)
-
-        await service.refreshBundle()
-
-        #expect(service.bundleEntries.isEmpty)
-        #expect(service.bundleCheckStatus == .untrusted)
-        #expect(mock.executedCommands.isEmpty)
-        service.customBrewfilePath = otherBrewfile.path
-
-        await service.fetchBundleEntries()
-        await service.checkBundle()
-        await service.refreshBundle()
-
-        #expect(service.brewfileURL?.path == otherBrewfile.path)
         #expect(service.bundleCheckStatus == .untrusted)
         #expect(mock.executedCommands.isEmpty)
     }
@@ -340,7 +313,7 @@ struct BrewServiceBundleTests {
         service.customBrewfilePath = brewfile.path
         Self.setEmptyBundleListResults(mock, path: brewfile.path)
         mock.setResult(
-            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            for: ["bundle", "check", "--verbose", "--file=-"],
             output: "The Brewfile's dependencies are satisfied.\n"
         )
 
@@ -360,18 +333,18 @@ struct BrewServiceBundleTests {
         service.customBrewfilePath = brewfile.path
         #expect(service.trustBrewfile(at: brewfile))
         mock.setResult(
-            for: ["bundle", "list", "--formula", "--file", brewfile.path],
+            for: ["bundle", "list", "--formula", "--file=-"],
             output: "Error: Permission denied @ rb_sysopen - \(brewfile.path)\n",
             success: false
         )
         mock.setResult(
-            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            for: ["bundle", "check", "--verbose", "--file=-"],
             output: "The Brewfile's dependencies are satisfied.\n"
         )
 
         await service.refreshBundle()
 
-        #expect(mock.executedCommands == [["bundle", "list", "--formula", "--file", brewfile.path]])
+        #expect(mock.executedCommands == [["bundle", "list", "--formula", "--file=-"]])
         if case .failed(let message) = service.bundleCheckStatus {
             #expect(message.contains("Permission denied"))
         } else {
@@ -388,7 +361,7 @@ struct BrewServiceBundleTests {
         #expect(service.trustBrewfile(at: brewfile))
         Self.setBundleListResults(mock, path: brewfile.path)
         mock.setResult(
-            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            for: ["bundle", "check", "--verbose", "--file=-"],
             output: "The Brewfile's dependencies are satisfied.\n"
         )
 
@@ -396,26 +369,26 @@ struct BrewServiceBundleTests {
 
         #expect(mock.executedCommands.count == 5)
         for command in mock.executedCommands {
-            #expect(command.contains("--file"))
-            #expect(command.last == brewfile.path)
+            #expect(command.last == "--file=-")
         }
+        #expect(mock.standardInputs.count == 5)
+        #expect(mock.standardInputs.allSatisfy { $0.data == Data() })
     }
 
-    @Test("dumpBundle passes force so a panel-confirmed replace overwrites")
+    @Test("dumpBundle writes through a private generated file")
     func dumpBundleForcesOverwrite() async throws {
         let brewfile = try Self.makeBrewfile()
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
-        mock.setResult(
-            for: ["bundle", "dump", "--force", "--file", brewfile.path],
-            output: "brew crashed\n",
-            success: false
-        )
 
         let result = await service.dumpBundle(to: brewfile)
 
         #expect(result.success == false)
-        #expect(mock.executedCommands == [["bundle", "dump", "--force", "--file", brewfile.path]])
+        let command = try #require(mock.executedCommands.first)
+        #expect(Array(command.prefix(4)) == ["bundle", "dump", "--force", "--file"])
+        #expect(command.count == 5)
+        #expect(command.last != "-")
+        #expect(command.last != brewfile.path)
         #expect(service.lastError != nil)
         #expect(service.actionHistory.count == 1)
         #expect(service.actionHistory[0].status == .failure)
@@ -426,10 +399,20 @@ struct BrewServiceBundleTests {
         let brewfile = try Self.makeBrewfile()
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
-        mock.setResult(for: ["bundle", "dump", "--force", "--file", brewfile.path], output: "Using Brewfile\n")
+        let generatedData = Data("brew \"wget\"\n".utf8)
+        mock.setCommandHandler { arguments in
+            guard Array(arguments.prefix(4)) == ["bundle", "dump", "--force", "--file"],
+                  let path = arguments.last else { return nil }
+            do {
+                try generatedData.write(to: URL(fileURLWithPath: path))
+                return CommandResult(output: "Auto-updated Homebrew!\n", success: true)
+            } catch {
+                return CommandResult(output: error.localizedDescription, success: false)
+            }
+        }
         Self.setEmptyBundleListResults(mock, path: brewfile.path)
         mock.setResult(
-            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            for: ["bundle", "check", "--verbose", "--file=-"],
             output: "The Brewfile's dependencies are satisfied.\n"
         )
 
@@ -439,7 +422,9 @@ struct BrewServiceBundleTests {
         #expect(service.customBrewfilePath == brewfile.path)
         #expect(service.bundleCheckStatus == .satisfied)
         #expect(service.actionHistory.first?.status == .success)
-        #expect(mock.executedCommands.last == ["bundle", "check", "--verbose", "--file", brewfile.path])
+        #expect(mock.executedCommands.last == ["bundle", "check", "--verbose", "--file=-"])
+        #expect(try String(contentsOf: brewfile, encoding: .utf8) == "brew \"wget\"\n")
+        #expect(service.brewfileSnapshot?.data == generatedData)
     }
 
     @Test("existing empty Brewfile refreshes to satisfied empty state")
@@ -451,7 +436,7 @@ struct BrewServiceBundleTests {
         #expect(service.trustBrewfile(at: brewfile))
         Self.setEmptyBundleListResults(mock, path: brewfile.path)
         mock.setResult(
-            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            for: ["bundle", "check", "--verbose", "--file=-"],
             output: "The Brewfile's dependencies are satisfied.\n"
         )
 
@@ -463,18 +448,18 @@ struct BrewServiceBundleTests {
         #expect(service.bundleCheckStatus == .satisfied)
     }
 
-    private static func setBundleListResults(_ mock: MockCommandRunner, path: String) {
-        mock.setResult(for: ["bundle", "list", "--formula", "--file", path], output: "wget\ncurl\n")
-        mock.setResult(for: ["bundle", "list", "--cask", "--file", path], output: "firefox\n")
-        mock.setResult(for: ["bundle", "list", "--tap", "--file", path], output: "homebrew/core\nhomebrew/cask\n")
-        mock.setResult(for: ["bundle", "list", "--mas", "--file", path], output: "Xcode\n")
+    private static func setBundleListResults(_ mock: MockCommandRunner, path _: String) {
+        mock.setResult(for: ["bundle", "list", "--formula", "--file=-"], output: "wget\ncurl\n")
+        mock.setResult(for: ["bundle", "list", "--cask", "--file=-"], output: "firefox\n")
+        mock.setResult(for: ["bundle", "list", "--tap", "--file=-"], output: "homebrew/core\nhomebrew/cask\n")
+        mock.setResult(for: ["bundle", "list", "--mas", "--file=-"], output: "Xcode\n")
     }
 
-    private static func setEmptyBundleListResults(_ mock: MockCommandRunner, path: String) {
-        mock.setResult(for: ["bundle", "list", "--formula", "--file", path], output: "")
-        mock.setResult(for: ["bundle", "list", "--cask", "--file", path], output: "")
-        mock.setResult(for: ["bundle", "list", "--tap", "--file", path], output: "")
-        mock.setResult(for: ["bundle", "list", "--mas", "--file", path], output: "")
+    private static func setEmptyBundleListResults(_ mock: MockCommandRunner, path _: String) {
+        mock.setResult(for: ["bundle", "list", "--formula", "--file=-"], output: "")
+        mock.setResult(for: ["bundle", "list", "--cask", "--file=-"], output: "")
+        mock.setResult(for: ["bundle", "list", "--tap", "--file=-"], output: "")
+        mock.setResult(for: ["bundle", "list", "--mas", "--file=-"], output: "")
     }
 
     private static func makeBrewfile(contents: String = "") throws -> URL {

--- a/BrewyTests/BrewServiceTests.swift
+++ b/BrewyTests/BrewServiceTests.swift
@@ -352,33 +352,6 @@ struct CommandRunnerTests {
         }
     }
 
-    @Test("resolvedPrivilegedBrewPath rejects non-standard executables")
-    func privilegedPathRejectsNonStandardExecutable() {
-        let path = CommandRunner.resolvedPrivilegedBrewPath(preferred: "/bin/sh")
-        #expect(path == nil)
-    }
-
-    @Test("resolvedPrivilegedBrewPath accepts symlink to standard executable")
-    func privilegedPathAcceptsSymlinkToStandardExecutable() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("brewy-command-runner-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: directory) }
-
-        let standardBrew = directory.appendingPathComponent("brew")
-        let alias = directory.appendingPathComponent("custom-brew")
-        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: standardBrew)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: standardBrew.path)
-        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: standardBrew)
-
-        let path = CommandRunner.resolvedPrivilegedBrewPath(
-            preferred: alias.path,
-            standardPaths: [standardBrew.path]
-        )
-
-        #expect(path == standardBrew.path)
-    }
-
     @Test("automatic Homebrew update prevention defaults off")
     func automaticHomebrewUpdatePreventionDefaultsOff() throws {
         let suiteName = "io.linnane.brewy.tests.\(UUID().uuidString)"
@@ -408,6 +381,18 @@ struct CommandRunnerTests {
         )
 
         #expect(env["HOMEBREW_NO_AUTO_UPDATE"] == nil)
+    }
+
+    @Test("Homebrew Bundle always prevents auto-update output")
+    func bundleAlwaysPreventsAutomaticUpdate() throws {
+        let suiteName = "io.linnane.brewy.tests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(CommandRunner.shouldPreventHomebrewAutoUpdate(for: ["bundle", "list"], userDefaults: defaults))
+        #expect(!CommandRunner.shouldPreventHomebrewAutoUpdate(for: ["info"], userDefaults: defaults))
+        defaults.set(true, forKey: CommandRunner.preventHomebrewAutoUpdateKey)
+        #expect(CommandRunner.shouldPreventHomebrewAutoUpdate(for: ["info"], userDefaults: defaults))
     }
 }
 

--- a/BrewyTests/BrewfileSnapshotTests.swift
+++ b/BrewyTests/BrewfileSnapshotTests.swift
@@ -1,0 +1,122 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+@Suite("Brewfile Snapshots")
+@MainActor
+struct BrewfileSnapshotTests {
+    @Test("disk edits and path changes require trust again")
+    func diskEditsAndPathChangesRequireTrust() async throws {
+        let brewfile = try Self.makeBrewfile(contents: "brew \"wget\"\n")
+        let otherBrewfile = try Self.makeBrewfile(contents: "brew \"curl\"\n")
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        #expect(service.trustBrewfile(at: brewfile))
+        try "brew \"curl\"\n".write(to: brewfile, atomically: true, encoding: .utf8)
+
+        await service.refreshBundle()
+
+        #expect(service.bundleCheckStatus == .untrusted)
+        #expect(mock.executedCommands.isEmpty)
+        service.customBrewfilePath = otherBrewfile.path
+
+        await service.fetchBundleEntries()
+        await service.checkBundle()
+        await service.refreshBundle()
+
+        #expect(service.brewfileURL?.path == otherBrewfile.path)
+        #expect(service.bundleCheckStatus == .untrusted)
+        #expect(mock.executedCommands.isEmpty)
+    }
+
+    @Test("unchanged trusted bytes are reread and sent exactly")
+    func unchangedTrustedBytesAreSentExactly() async throws {
+        let approvedBytes = Data("brew \"wget\"\n".utf8)
+        let brewfile = try Self.makeBrewfile(contents: "brew \"wget\"\n")
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        #expect(service.trustBrewfile(at: brewfile))
+        service.brewfileSnapshot = nil
+        Self.setBundleListResults(mock)
+        mock.setResult(
+            for: ["bundle", "check", "--verbose", "--file=-"],
+            output: "The Brewfile's dependencies are satisfied.\n"
+        )
+
+        await service.refreshBundle()
+
+        #expect(service.bundleCheckStatus == .satisfied)
+        #expect(mock.standardInputs.count == 5)
+        #expect(mock.standardInputs.allSatisfy { $0.data == approvedBytes })
+    }
+
+    @Test("changed source cannot recreate a missing trusted snapshot")
+    func changedSourceCannotRecreateSnapshot() async throws {
+        let brewfile = try Self.makeBrewfile(contents: "brew \"wget\"\n")
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        #expect(service.trustBrewfile(at: brewfile))
+        service.brewfileSnapshot = nil
+        try "brew \"curl\"\n".write(to: brewfile, atomically: true, encoding: .utf8)
+
+        await service.refreshBundle()
+
+        #expect(service.bundleCheckStatus == .untrusted)
+        #expect(mock.executedCommands.isEmpty)
+    }
+
+    @Test("trust follows symbolic links but rejects directories and oversized files")
+    func trustAcceptsLinksToRegularFiles() throws {
+        let target = try Self.makeBrewfile(contents: "brew \"wget\"\n")
+        let symlink = target.deletingLastPathComponent().appendingPathComponent("LinkedBrewfile")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: target)
+        let directory = target.deletingLastPathComponent()
+        let oversized = directory.appendingPathComponent("OversizedBrewfile")
+        try Data(repeating: 0x41, count: BrewfileSnapshot.maximumByteCount + 1).write(to: oversized)
+        let (service, _) = makeService(mock: MockCommandRunner())
+
+        #expect(service.trustBrewfile(at: symlink))
+        #expect(service.brewfileSnapshot?.sourcePath == symlink.standardizedFileURL.path)
+        #expect(service.brewfileSnapshot?.data == Data("brew \"wget\"\n".utf8))
+        #expect(!service.trustBrewfile(at: directory))
+        #expect(!service.trustBrewfile(at: oversized))
+    }
+
+    @Test("retargeting a trusted symbolic link requires trust again")
+    func retargetedLinkRequiresTrust() async throws {
+        let firstTarget = try Self.makeBrewfile(contents: "brew \"wget\"\n")
+        let secondTarget = try Self.makeBrewfile(contents: "brew \"curl\"\n")
+        let symlink = firstTarget.deletingLastPathComponent().appendingPathComponent("LinkedBrewfile")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: firstTarget)
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = symlink.path
+        #expect(service.trustBrewfile(at: symlink))
+        try FileManager.default.removeItem(at: symlink)
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: secondTarget)
+
+        await service.refreshBundle()
+
+        #expect(service.bundleCheckStatus == .untrusted)
+        #expect(mock.executedCommands.isEmpty)
+    }
+
+    private static func setBundleListResults(_ mock: MockCommandRunner) {
+        mock.setResult(for: ["bundle", "list", "--formula", "--file=-"], output: "wget\ncurl\n")
+        mock.setResult(for: ["bundle", "list", "--cask", "--file=-"], output: "firefox\n")
+        mock.setResult(for: ["bundle", "list", "--tap", "--file=-"], output: "homebrew/core\n")
+        mock.setResult(for: ["bundle", "list", "--mas", "--file=-"], output: "Xcode\n")
+    }
+
+    private static func makeBrewfile(contents: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BrewySnapshotTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let brewfile = directory.appendingPathComponent("Brewfile")
+        try contents.write(to: brewfile, atomically: true, encoding: .utf8)
+        return brewfile
+    }
+}

--- a/BrewyTests/BundleRetryTests.swift
+++ b/BrewyTests/BundleRetryTests.swift
@@ -16,12 +16,22 @@ struct BundleRetryTests {
         )
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
-        mock.setResult(for: arguments, output: "Using Brewfile\n")
+        let generatedData = Data("brew \"wget\"\n".utf8)
+        mock.setCommandHandler { command in
+            guard Array(command.prefix(4)) == ["bundle", "dump", "--force", "--file"],
+                  let path = command.last else { return nil }
+            do {
+                try generatedData.write(to: URL(fileURLWithPath: path))
+                return CommandResult(output: "Created Brewfile", success: true)
+            } catch {
+                return CommandResult(output: error.localizedDescription, success: false)
+            }
+        }
         for flag in ["--formula", "--cask", "--tap", "--mas"] {
-            mock.setResult(for: ["bundle", "list", flag, "--file", brewfile.path], output: "")
+            mock.setResult(for: ["bundle", "list", flag, "--file=-"], output: "")
         }
         mock.setResult(
-            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            for: ["bundle", "check", "--verbose", "--file=-"],
             output: "The Brewfile's dependencies are satisfied.\n"
         )
 

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -128,6 +128,46 @@ struct CommandRunnerProcessTests {
         #expect(result.output.contains("hello world"))
     }
 
+    @Test("runExecutable provides exact standard-input bytes")
+    func exactStandardInput() async throws {
+        let input = Data("brew \"wget\"\n# approved bytes\n".utf8)
+        let expected = try #require(String(data: input, encoding: .utf8))
+        let result = await CommandRunner.runExecutable(
+            "/bin/cat",
+            arguments: [],
+            standardInput: input
+        )
+
+        #expect(result.success)
+        #expect(result.standardOutput == expected)
+    }
+
+    @Test("runExecutable terminates a child that closes standard input and keeps running")
+    func closedStandardInputTerminatesChild() async {
+        let start = ContinuousClock.now
+        let result = await CommandRunner.runExecutable(
+            "/bin/sh",
+            arguments: ["-c", "exec 0<&-; exec /bin/sleep 30"],
+            standardInput: Data(repeating: 0x41, count: 1_048_576),
+            timeout: .seconds(2)
+        )
+
+        #expect(!result.success)
+        #expect(result.output.contains("Failed to provide command input"))
+        #expect(ContinuousClock.now - start < .seconds(10))
+    }
+
+    @Test("runExecutable preserves invalid UTF-8 as replacement text")
+    func invalidUTF8IsNotDiscarded() async {
+        let result = await CommandRunner.runExecutable(
+            "/bin/sh",
+            arguments: ["-c", "printf '\\377'"]
+        )
+
+        #expect(result.success)
+        #expect(result.standardOutput == "\u{FFFD}")
+    }
+
     @Test("runExecutable reports failure for nonzero exit")
     func nonzeroExit() async {
         let result = await CommandRunner.runExecutable("/usr/bin/false", arguments: [])
@@ -256,6 +296,20 @@ struct CommandRunnerProcessTests {
         #expect(lineCount >= 10_000)
     }
 
+    @Test("runExecutable bounds pipe draining after the leader exits")
+    func exitedLeaderWithOpenPipeReturns() async throws {
+        let start = ContinuousClock.now
+        let result = await CommandRunner.runExecutable(
+            "/bin/sh",
+            arguments: ["-c", "sleep 30 & printf '%s' \"$!\""]
+        )
+        let childPID = try #require(Int32(result.standardOutput))
+        defer { Darwin.kill(childPID, SIGKILL) }
+
+        #expect(result.success)
+        #expect(ContinuousClock.now - start < .seconds(15))
+    }
+
     @Test("Task cancellation terminates the child process")
     func cancellationTerminatesProcess() async {
         let task = Task {
@@ -323,6 +377,27 @@ struct CommandRunnerProcessTests {
             CommandRunner.terminationOutput(message, succeeded: false)
                 == "\(message)\nSome child processes may still be running."
         )
+    }
+
+    @Test("Input failure preserves cancellation state")
+    func inputFailurePreservesCancellation() {
+        let cancelled = CommandResult(
+            output: "Command was cancelled.",
+            success: false,
+            cancelled: true,
+            standardOutput: "partial",
+            exitCode: SIGTERM
+        )
+
+        let result = CommandRunner.inputFailureResult(
+            "Failed to provide command input.",
+            processResult: cancelled,
+            terminationSucceeded: true
+        )
+
+        #expect(result.cancelled)
+        #expect(!result.success)
+        #expect(result.standardOutput == "partial")
     }
 
     @Test("Streaming delivers output and matches the final result")

--- a/BrewyTests/DependencyTreeTests.swift
+++ b/BrewyTests/DependencyTreeTests.swift
@@ -5,16 +5,19 @@ import Testing
 private func makePackage(
     name: String,
     installedOnRequest: Bool = true,
-    dependencies: [String] = []
+    dependencies: [String] = [],
+    source: PackageSource = .formula,
+    dependencyReferences: [PackageReference]? = nil
 ) -> BrewPackage {
     BrewPackage(
-        id: "formula-\(name)", name: name, version: "1.0",
+        id: "\(source.rawValue)-\(name)", name: name, version: "1.0",
         description: "", homepage: "",
         isInstalled: true, isOutdated: false,
         installedVersion: "1.0", latestVersion: nil,
-        source: .formula, pinned: false,
+        source: source, pinned: false,
         installedOnRequest: installedOnRequest,
-        dependencies: dependencies
+        dependencies: dependencies,
+        dependencyReferences: dependencyReferences
     )
 }
 
@@ -67,10 +70,10 @@ struct BrewServiceDependencyTreeTests {
         let ids = Set(tree.flatMap { node -> [String] in
             [node.id] + (node.children?.map(\.id) ?? [])
         })
-        #expect(ids.contains("z>a"))
-        #expect(ids.contains("z>b"))
-        #expect(ids.contains("z>a>top"))
-        #expect(ids.contains("z>b>top"))
+        #expect(ids.contains("formula-z>formula-a"))
+        #expect(ids.contains("formula-z>formula-b"))
+        #expect(ids.contains("formula-z>formula-a>formula-top"))
+        #expect(ids.contains("formula-z>formula-b>formula-top"))
     }
 
     @Test("Reverse tree guards against cycles in the ancestor chain")
@@ -167,11 +170,34 @@ struct BrewServiceDependencyTreeTests {
             )
         ]
 
-        // Building the name-keyed lookup must not trap on the duplicate "docker"; the formula
-        // (which carries the dependency) wins, so the tree resolves down to openssl.
         let tree = service.forwardDependencyTree(for: "docker")
         #expect(tree.count == 1)
         #expect(tree[0].name == "openssl")
+        #expect(service.forwardDependencyTree(for: "docker", source: .cask).isEmpty)
+    }
+
+    @Test("Dependency trees preserve formula and cask identity for duplicate names")
+    func dependencyTreesPreservePackageSource() {
+        let formulaShared = makePackage(name: "shared", source: .formula)
+        let caskShared = makePackage(name: "shared", source: .cask)
+        let formulaParent = makePackage(name: "formula-parent", dependencies: ["shared"])
+        let caskParent = makePackage(
+            name: "cask-parent",
+            dependencies: ["shared"],
+            source: .cask,
+            dependencyReferences: [PackageReference(name: "shared", source: .cask)]
+        )
+        let service = BrewService()
+        service.installedFormulae = [formulaShared, formulaParent]
+        service.installedCasks = [caskShared, caskParent]
+
+        let formulaParents = service.reverseDependencyTree(for: formulaShared)
+        let caskParents = service.reverseDependencyTree(for: caskShared)
+        let caskDependencies = service.forwardDependencyTree(for: caskParent)
+
+        #expect(formulaParents.map(\.packageID) == [formulaParent.id])
+        #expect(caskParents.map(\.packageID) == [caskParent.id])
+        #expect(caskDependencies.map(\.packageID) == [caskShared.id])
     }
 
     @Test("maxNodes bounds the total node count for hub packages")

--- a/BrewyTests/HistoryTests.swift
+++ b/BrewyTests/HistoryTests.swift
@@ -121,6 +121,18 @@ struct ActionHistoryEntryTests {
         #expect(entry.isRetryable == false)
     }
 
+    @Test("isRetryable blocks Brewfile-consuming bundle history")
+    func bundleReadIsNotRetryable() {
+        let entry = ActionHistoryEntry(
+            id: UUID(), command: "bundle",
+            arguments: ["bundle", "check", "--file", "/tmp/Brewfile"],
+            packageName: nil, packageSource: nil,
+            status: .failure, output: "Error", timestamp: Date()
+        )
+
+        #expect(entry.isRetryable == false)
+    }
+
     @Test("isMutatingCommand is true for mutating commands")
     func isMutatingCommandForMutations() {
         for command in ["cleanup", "pin", "unpin"] {
@@ -155,6 +167,7 @@ struct ActionHistoryEntryTests {
         #expect(entry.isMutatingCommand)
         #expect(entry.isBundleDump)
         #expect(entry.bundleDumpURL?.path == "/tmp/Brewfile")
+        #expect(entry.isRetryable)
     }
 
     @Test("Status raw values encode correctly")

--- a/BrewyTests/JSONAndServicesTests.swift
+++ b/BrewyTests/JSONAndServicesTests.swift
@@ -130,7 +130,7 @@ struct JSONParsingEdgeCaseTests {
 struct ServicesIntegrationTests {
 
     @Test("fetchServices uses info format first, falls back to list")
-    func fetchServicesFallback() async {
+    func fetchServicesFallback() async throws {
         let mock = MockCommandRunner()
         let service = BrewService(commandRunner: mock)
         let serviceJSON = """
@@ -142,14 +142,14 @@ struct ServicesIntegrationTests {
             output: serviceJSON
         )
 
-        let services = await service.fetchServices()
+        let services = try await service.fetchServices()
 
         #expect(services.count == 1)
         #expect(services[0].name == "postgresql@14")
     }
 
     @Test("fetchServices falls back to list when info returns empty")
-    func fetchServicesFallbackToList() async {
+    func fetchServicesFallbackToList() async throws {
         let mock = MockCommandRunner()
         let service = BrewService(commandRunner: mock)
         mock.setResult(for: ["services", "info", "--all", "--json"], output: "[]")
@@ -158,24 +158,36 @@ struct ServicesIntegrationTests {
         """
         mock.setResult(for: ["services", "list", "--json"], output: serviceJSON)
 
-        let services = await service.fetchServices()
+        let services = try await service.fetchServices()
 
         #expect(services.count == 1)
         #expect(services[0].name == "redis")
     }
 
-    @Test("fetchServices returns empty when both service commands fail")
+    @Test("fetchServices reports an error when both service commands fail")
     func fetchServicesDoubleFailure() async {
         let mock = MockCommandRunner()
         let service = BrewService(commandRunner: mock)
         mock.setResult(for: ["services", "info", "--all", "--json"], output: "info failed", success: false)
         mock.setResult(for: ["services", "list", "--json"], output: "list failed", success: false)
 
-        let services = await service.fetchServices()
-
-        #expect(services.isEmpty)
+        await #expect(throws: ServicesFetchError.self) {
+            try await service.fetchServices()
+        }
         #expect(mock.executedCommands.contains(["services", "info", "--all", "--json"]))
         #expect(mock.executedCommands.contains(["services", "list", "--json"]))
+    }
+
+    @Test("fetchServices preserves a valid empty info response when compatibility fallback fails")
+    func fetchServicesValidEmptyResponse() async throws {
+        let mock = MockCommandRunner()
+        let service = BrewService(commandRunner: mock)
+        mock.setResult(for: ["services", "info", "--all", "--json"], output: "[]")
+        mock.setResult(for: ["services", "list", "--json"], output: "unsupported", success: false)
+
+        let services = try await service.fetchServices()
+
+        #expect(services.isEmpty)
     }
 
     @Test("cleanupServices runs brew services cleanup")

--- a/BrewyTests/PipeReaderTests.swift
+++ b/BrewyTests/PipeReaderTests.swift
@@ -42,4 +42,20 @@ struct PipeReaderTests {
 
         #expect(String(bytes: data, encoding: .utf8) == "partial")
     }
+
+    @Test("Reader drains to EOF while bounding retained output")
+    func boundsRetainedOutput() async throws {
+        let pipe = Pipe()
+        let reader = PipeReader(pipe: pipe, label: "bounded test", maximumByteCount: 64)
+        reader.start()
+
+        try pipe.fileHandleForWriting.write(contentsOf: Data(repeating: 0x41, count: 4_096))
+        try pipe.fileHandleForWriting.close()
+        let data = await Task.detached(priority: .medium) {
+            reader.wait { nil }
+        }.value
+
+        #expect(data.count <= 64)
+        #expect(String(bytes: data, encoding: .utf8)?.contains("output truncated") == true)
+    }
 }

--- a/BrewyTests/ReleaseNotesFeedTests.swift
+++ b/BrewyTests/ReleaseNotesFeedTests.swift
@@ -1,0 +1,81 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+private class OversizedFeedURLProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "release-feed.test"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: 200,
+                  httpVersion: "HTTP/1.1",
+                  headerFields: [:]
+              ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(
+            self,
+            didLoad: Data(repeating: 0x41, count: AppcastParser.maximumFeedByteCount + 1)
+        )
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@Suite("Release Notes Feed", .serialized)
+struct ReleaseNotesFeedTests {
+    @Test("streaming rejects an oversized response without Content-Length")
+    func rejectsUnknownLengthOversizedResponse() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [OversizedFeedURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+        let url = try #require(URL(string: "https://release-feed.test/appcast.xml"))
+
+        await #expect(throws: ReleaseNotesFeed.FeedError.self) {
+            try await ReleaseNotesFeed.load(from: url, session: session)
+        }
+    }
+
+    @Test("parser rejects entity declarations before expansion")
+    func rejectsEntityDeclarations() throws {
+        let xml = """
+        <!DOCTYPE rss [<!ENTITY repeated "release notes">]>
+        <rss><channel><item><title>&repeated;</title></item></channel></rss>
+        """
+        let data = try #require(xml.data(using: .utf8))
+
+        #expect(AppcastParser().parse(data: data) == nil)
+    }
+
+    @Test("real rendering path converts sanitized HTML on the main actor")
+    @MainActor
+    func rendersReleaseNotesThroughRealPath() async throws {
+        let xml = """
+        <rss xmlns:sparkle="https://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel><item>
+            <title>Brewy 1.2.3</title>
+            <sparkle:shortVersionString>1.2.3</sparkle:shortVersionString>
+            <description><![CDATA[<p>Hello <strong>Brewy</strong></p>]]></description>
+          </item></channel>
+        </rss>
+        """
+        let data = try #require(xml.data(using: .utf8))
+
+        let (release, notes) = await ReleaseNotesFeed.parseAndRender(data)
+
+        #expect(release?.version == "1.2.3")
+        #expect(notes.map { String($0.characters) }?.contains("Hello Brewy") == true)
+    }
+}

--- a/BrewyTests/SecurityHelpersTests.swift
+++ b/BrewyTests/SecurityHelpersTests.swift
@@ -22,6 +22,7 @@ struct ExternalURLPolicyTests {
 }
 
 @Suite("ReleaseNotesHTML")
+@MainActor
 struct ReleaseNotesHTMLTests {
 
     @Test("Removes unsafe link attributes")
@@ -59,6 +60,20 @@ struct ReleaseNotesHTMLTests {
 
         #expect(stripped.range(of: "<img", options: .caseInsensitive) == nil)
         #expect(stripped.range(of: "src=", options: .caseInsensitive) == nil)
+    }
+
+    @Test("Deeply reforming markup is neutralized in one pass")
+    func deeplyReformingMarkupIsNeutralized() {
+        let payload = String(repeating: "<", count: 20) + String(repeating: "img>", count: 20)
+        let stripped = ReleaseNotesHTML.stripUnsafeMarkup(from: payload)
+
+        #expect(stripped.range(of: "<img", options: .caseInsensitive) == nil)
+    }
+
+    @Test("Oversized markup is rejected before HTML conversion")
+    func oversizedMarkupIsRejected() {
+        let payload = String(repeating: "a", count: ReleaseNotesHTML.maximumHTMLByteCount + 1)
+        #expect(ReleaseNotesHTML.attributedString(from: payload) == nil)
     }
 }
 

--- a/BrewyTests/ServicesTests.swift
+++ b/BrewyTests/ServicesTests.swift
@@ -194,21 +194,8 @@ struct BrewServiceServicesControlTests {
 
         _ = await service.restartService("redis")
         #expect(mock.executedExecutables.last?.arguments == ["services", "restart", "redis"])
+        #expect(mock.executedExecutables.allSatisfy { $0.path.hasSuffix("brew") })
+        #expect(mock.executedExecutables.allSatisfy { $0.path != "/usr/bin/osascript" })
     }
 
-    @Test("asSudo runs brew via osascript with administrator privileges")
-    func startServiceAsSudo() async {
-        let mock = MockCommandRunner()
-        let (service, _) = makeService(mock: mock)
-
-        _ = await service.startService("redis", asSudo: true)
-
-        // osascript -e <privileged script> <brewPath> services start redis
-        let args = mock.executedExecutables.last?.arguments ?? []
-        #expect(mock.executedExecutables.last?.path == "/usr/bin/osascript")
-        #expect(args.first == "-e")
-        #expect(args.dropFirst().first?.contains("administrator privileges") == true)
-        #expect(args.dropFirst(2).first?.hasSuffix("brew") == true)
-        #expect(Array(args.suffix(3)) == ["services", "start", "redis"])
-    }
 }

--- a/BrewyTests/TapAndConfigTests.swift
+++ b/BrewyTests/TapAndConfigTests.swift
@@ -385,6 +385,49 @@ struct AppcastParserTests {
         // Sparkle feeds list newest first, so the first item (0.2.0) is the one we want.
         #expect(release.version == "0.2.0")
     }
+
+    @Test("Rejects appcasts above the response limit")
+    func rejectsOversizedAppcast() {
+        let data = Data(repeating: 0x41, count: AppcastParser.maximumFeedByteCount + 1)
+        #expect(AppcastParser().parse(data: data) == nil)
+    }
+
+    @Test("Rejects oversized first-item descriptions")
+    func rejectsOversizedDescription() throws {
+        let description = String(repeating: "a", count: AppcastParser.maximumDescriptionByteCount + 1)
+        let xml = "<rss><channel><item><title>Release</title><description>\(description)</description></item></channel></rss>"
+        let data = try #require(xml.data(using: .utf8))
+
+        #expect(AppcastParser().parse(data: data) == nil)
+    }
+
+    @Test("Rejects oversized first-item titles")
+    func rejectsOversizedTitle() throws {
+        let title = String(repeating: "a", count: 5_000)
+        let xml = "<rss><channel><item><title>\(title)</title></item></channel></rss>"
+        let data = try #require(xml.data(using: .utf8))
+
+        #expect(AppcastParser().parse(data: data) == nil)
+    }
+
+    @Test("Stops parsing after the first complete item")
+    func stopsAfterFirstItem() throws {
+        let oversizedSecondDescription = String(
+            repeating: "b",
+            count: AppcastParser.maximumDescriptionByteCount + 1
+        )
+        let xml = """
+        <rss><channel>
+          <item><title>Current</title><sparkle:shortVersionString>2.0</sparkle:shortVersionString></item>
+          <item><title>Old</title><description>\(oversizedSecondDescription)</description></item>
+        </channel></rss>
+        """
+        let data = try #require(xml.data(using: .utf8))
+        let release = try #require(AppcastParser().parse(data: data))
+
+        #expect(release.title == "Current")
+        #expect(release.version == "2.0")
+    }
 }
 
 // MARK: - AppcastRelease Tests

--- a/BrewyTests/TestHelpers.swift
+++ b/BrewyTests/TestHelpers.swift
@@ -11,15 +11,21 @@ final class MockCommandRunner: CommandRunning, @unchecked Sendable {
     private var _executedCommands: [[String]] = []
     private var _executedExecutables: [(path: String, arguments: [String])] = []
     private var _recordedTimeouts: [[String]: Duration] = [:]
+    private var _standardInputs: [(arguments: [String], data: Data)] = []
+    private var _commandHandler: (@Sendable ([String]) -> CommandResult?)?
 
     var executedCommands: [[String]] {
         lock.withLock { _executedCommands }
     }
 
     /// Records the executable/brew path alongside arguments so tests can assert *which* binary ran
-    /// (brew vs mas vs sudo) — `executedCommands` keys on arguments alone.
+    /// (`brew` vs `mas`) — `executedCommands` keys on arguments alone.
     var executedExecutables: [(path: String, arguments: [String])] {
         lock.withLock { _executedExecutables }
+    }
+
+    var standardInputs: [(arguments: [String], data: Data)] {
+        lock.withLock { _standardInputs }
     }
 
     func setResult(for arguments: [String], output: String, success: Bool = true) {
@@ -40,35 +46,60 @@ final class MockCommandRunner: CommandRunning, @unchecked Sendable {
         }
     }
 
+    func setCommandHandler(_ handler: @escaping @Sendable ([String]) -> CommandResult?) {
+        lock.withLock {
+            _commandHandler = handler
+        }
+    }
+
     /// The timeout the service passed for these arguments (last invocation wins).
     func recordedTimeout(for arguments: [String]) -> Duration? {
         lock.withLock { _recordedTimeouts[arguments] }
     }
 
     func run(_ arguments: [String], brewPath: String, timeout: Duration) async -> CommandResult {
-        let (delay, result) = lock.withLock {
+        let (delay, result, handler) = lock.withLock {
             _executedCommands.append(arguments)
             _executedExecutables.append((path: brewPath, arguments: arguments))
             _recordedTimeouts[arguments] = timeout
-            return (_delays[arguments], _results[arguments] ?? CommandResult(output: "", success: false))
+            return (_delays[arguments], _results[arguments], _commandHandler)
         }
         if let delay {
             try? await Task.sleep(for: delay)
         }
-        return result
+        return result ?? handler?(arguments) ?? CommandResult(output: "", success: false)
+    }
+
+    func run(
+        _ arguments: [String],
+        brewPath: String,
+        standardInput: Data,
+        timeout: Duration
+    ) async -> CommandResult {
+        let (delay, result, handler) = lock.withLock {
+            _executedCommands.append(arguments)
+            _executedExecutables.append((path: brewPath, arguments: arguments))
+            _recordedTimeouts[arguments] = timeout
+            _standardInputs.append((arguments: arguments, data: standardInput))
+            return (_delays[arguments], _results[arguments], _commandHandler)
+        }
+        if let delay {
+            try? await Task.sleep(for: delay)
+        }
+        return result ?? handler?(arguments) ?? CommandResult(output: "", success: false)
     }
 
     func runExecutable(_ executablePath: String, arguments: [String], timeout: Duration) async -> CommandResult {
-        let (delay, result) = lock.withLock {
+        let (delay, result, handler) = lock.withLock {
             _executedCommands.append(arguments)
             _executedExecutables.append((path: executablePath, arguments: arguments))
             _recordedTimeouts[arguments] = timeout
-            return (_delays[arguments], _results[arguments] ?? CommandResult(output: "", success: false))
+            return (_delays[arguments], _results[arguments], _commandHandler)
         }
         if let delay {
             try? await Task.sleep(for: delay)
         }
-        return result
+        return result ?? handler?(arguments) ?? CommandResult(output: "", success: false)
     }
 }
 

--- a/BrewyUITests/SidebarNavigationUITests.swift
+++ b/BrewyUITests/SidebarNavigationUITests.swift
@@ -1,9 +1,7 @@
-import CryptoKit
 import XCTest
 
 @MainActor
 final class SidebarNavigationUITests: XCTestCase {
-
     // Thread Sanitizer instrumentation slows the app under test enough that the
     // sidebar can take much longer than the unscaled timeouts to render, which
     // flaked these waits in CI's TSan job. Scale every timeout and settle delay
@@ -20,15 +18,7 @@ final class SidebarNavigationUITests: XCTestCase {
         continueAfterFailure = false
         fixtureDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("brewy-ui-tests-\(ProcessInfo.processInfo.globallyUniqueString)")
-        let homebrewDirectory = fixtureDirectory.appendingPathComponent("homebrew")
-        try FileManager.default.createDirectory(at: homebrewDirectory, withIntermediateDirectories: true)
-        let brewfileURL = homebrewDirectory.appendingPathComponent("Brewfile")
-            .resolvingSymlinksInPath()
-        let brewfileData = Data("brew \"ripgrep\"\ncask \"firefox\"\n".utf8)
-        try brewfileData.write(to: brewfileURL)
-        let brewfileDigest = SHA256.hash(data: brewfileData)
-            .map { String(format: "%02x", $0) }
-            .joined()
+        try FileManager.default.createDirectory(at: fixtureDirectory, withIntermediateDirectories: true)
 
         app = XCUIApplication()
         app.terminate()
@@ -39,9 +29,7 @@ final class SidebarNavigationUITests: XCTestCase {
             "-brewfilePath", "",
             "-showCasksByDefault", "NO",
             "-showDockIcon", "YES",
-            "-showMenuBarIcon", "YES",
-            "-trustedBrewfilePath", brewfileURL.path,
-            "-trustedBrewfileDigest", brewfileDigest
+            "-showMenuBarIcon", "YES"
         ]
         app.launchEnvironment["BREWY_UI_TESTING"] = "1"
         app.launchEnvironment["XDG_CONFIG_HOME"] = fixtureDirectory.path
@@ -57,7 +45,6 @@ final class SidebarNavigationUITests: XCTestCase {
     }
 
     // MARK: - Sidebar Category Navigation
-
     func testAllSidebarCategoriesRender() throws {
         let categories = [
             "Installed", "Formulae", "Casks", "Mac App Store", "Outdated",
@@ -66,7 +53,6 @@ final class SidebarNavigationUITests: XCTestCase {
         ]
 
         let sidebar = app.outlines.firstMatch
-
         for (index, category) in categories.enumerated() {
             let row = sidebar.staticTexts[category]
             let timeout = index == 0 ? Self.launchTimeout : Self.elementTimeout
@@ -259,6 +245,10 @@ final class SidebarNavigationUITests: XCTestCase {
             app.staticTexts["homebrew.mxcl.postgresql@17"],
             timeout: Self.elementTimeout,
             "Service details should render"
+        )
+        XCTAssertFalse(
+            app.descendants(matching: .any)["Run as root (sudo)"].exists,
+            "Service actions must not expose a privileged execution path"
         )
 
         sidebar.staticTexts["Groups"].click()
@@ -490,7 +480,6 @@ final class MenuBarSettingsUITests: XCTestCase {
         toggle.click()
         _ = waitUntil { self.checkedValue(of: toggle) == initialMenuBarIconState }
     }
-
     private static var isThreadSanitizerActive: Bool {
         (0..<_dyld_image_count()).contains { index in
             guard let name = _dyld_get_image_name(index) else { return false }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,15 +35,16 @@ just build       # debug build without local code signing
 just lint        # SwiftLint (--strict)
 just typos       # spell-check
 just test        # unit tests (BrewyTests; UI tests need code signing)
+just test-ui     # UI tests with an ad hoc-signed test runner
 just periphery   # unused-code scan
 just audit       # GitHub Actions audit (zizmor)
 just lychee      # README and CONTRIBUTING link check
-just check       # everything above
+just check       # full static and unit-test gate
 ```
 
 Once you've run `just install-hooks`, the pre-push hook runs `just check` automatically on `git push`.
 
-CI builds with `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES`, runs SwiftLint in `--strict` mode, audits workflows when they change, scans for unused code, and exercises the test suite under sanitizer configurations. Warnings and lint violations fail the build, so a clean `just check` locally is the best way to avoid CI surprises.
+CI builds with `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES`, runs SwiftLint in `--strict` mode, audits workflows when they change, scans for unused code, exercises unit tests under sanitizer configurations, and runs UI tests with an ad hoc-signed runner. Warnings and lint violations fail the build, so a clean `just check` locally is the best way to avoid CI surprises.
 
 Run `just lychee` after changing links in README or CONTRIBUTING.
 
@@ -60,13 +61,14 @@ Run `just lychee` after changing links in README or CONTRIBUTING.
 
 - **Conventional Commits**: every commit message and PR title must be `type(scope): description`, where `type` is one of `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`. CI enforces this on both the PR title and each commit.
 - **DCO sign-off**: every commit needs a `Signed-off-by:` trailer — use `git commit -s`. The `commit-msg` hook installed by `just install-hooks` rejects commits without it.
-- If you used an AI assistant, include a `Co-Authored-By:` trailer.
+- Do not identify an AI tool or model as an author, co-author, committer, or signatory. AI attribution does not belong in commit trailers.
 
 ## Pull requests
 
 - Never push to `main`. Create a feature branch and open a PR.
 - PRs are squash-merged with the PR number appended (e.g. `feat: add dependency tree (#123)`).
 - Keep PR descriptions to a short summary of the change.
+- If AI assisted with a PR, end the initial PR description with exactly one unformatted line: `AI disclosure: <model> with <how the output was verified>.`
 
 ## Architecture guardrails
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Brewy is a native macOS app for managing [Homebrew](https://brew.sh) packages, c
 
 It is designed for people who already use Homebrew and want a fast, inspectable Mac interface for the work they do repeatedly: reviewing what is installed, upgrading safely, cleaning up old dependencies, and understanding why a package is on the machine.
 
-<p align="center"><img src="assets/BrewyScreenshot.png" alt="Brewy main window showing installed packages, package categories, and package details" width="960"></p>
-
 ## Highlights
 
 - Browse installed formulae, casks, Mac App Store apps, pinned packages, leaves, and outdated packages.
@@ -22,7 +20,7 @@ It is designed for people who already use Homebrew and want a fast, inspectable 
 - Inspect package details, versions, dependencies, reverse dependencies, and recursive dependency trees.
 - Install, uninstall, upgrade, reinstall, fetch, pin, unpin, link, and unlink packages through native macOS controls.
 - Upgrade all outdated Homebrew packages at once, or select exactly which packages to upgrade.
-- Manage Homebrew services, including start, stop, restart, stale-service cleanup, and optional sudo actions.
+- Manage Homebrew services, including start, stop, restart, and stale-service cleanup.
 - Manage taps, with health checks for archived, moved, or missing GitHub repositories.
 - Group packages into custom collections for projects, roles, or cleanup work.
 - Review action history and retry failed commands when it is safe to do so.
@@ -42,13 +40,13 @@ It is designed for people who already use Homebrew and want a fast, inspectable 
 The best way to install Brewy is naturally with Homebrew. It's in [homebrew-cask](https://github.com/Homebrew/homebrew-cask):
 
 ```sh
-brew install brewy
+brew install --cask brewy
 ```
 
 Or install it from the [starhaven-io tap](https://github.com/starhaven-io/homebrew-tap):
 
 ```sh
-brew install starhaven-io/tap/brewy
+brew install --cask starhaven-io/tap/brewy
 ```
 
 You can also grab the latest release from the [GitHub releases page](https://github.com/starhaven-io/Brewy/releases).
@@ -75,7 +73,7 @@ All CLI execution is centralized through `CommandRunner`, which invokes binaries
 
 Destructive maintenance operations show Homebrew dry-run previews before they can run. External links from package data, tap data, and release notes must pass through `ExternalURLPolicy`, which restricts URLs to `http` and `https` before opening them outside the app.
 
-Brewfiles are treated as code, because `brew bundle` executes the Ruby they contain. Brewy never runs a Brewfile until you explicitly trust it in the Bundle view, and it pins a SHA-256 digest of the trusted file: if the file changes on disk for any reason, every bundle operation stops until you review and re-trust it.
+Brewfiles are treated as code, because `brew bundle` executes the Ruby they contain. Brewy never runs a Brewfile until you explicitly trust it in the Bundle view. It opens the selected file or symbolic-link target, requires a regular file no larger than 1 MB, pins its SHA-256 digest, and sends the exact approved bytes to Homebrew over standard input for every operation. If the file or link target changes, Brewy requires review and trust again. Because Homebrew receives the Brewfile through standard input, Brewfile code that depends on its source filename or directory should be run directly with `brew bundle` instead.
 
 Report suspected vulnerabilities privately by emailing [security@starhaven.io](mailto:security@starhaven.io) or using [GitHub's private vulnerability reporting](https://github.com/starhaven-io/Brewy/security/advisories/new). See the [security policy](SECURITY.md) for details.
 

--- a/justfile
+++ b/justfile
@@ -56,6 +56,42 @@ test:
         SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
         EXCLUDED_ARCHS=x86_64
 
+# Run UI tests with an ad hoc-signed app, test bundle, and runner
+test-ui:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    xcodebuild test \
+        -project Brewy.xcodeproj \
+        -scheme Brewy \
+        -destination 'platform=macOS' \
+        -only-testing:BrewyUITests \
+        -derivedDataPath {{ quote(derived_data_path) }} \
+        CODE_SIGN_STYLE=Manual \
+        CODE_SIGN_IDENTITY=- \
+        CODE_SIGNING_REQUIRED=YES \
+        CODE_SIGNING_ALLOWED=YES \
+        DEVELOPMENT_TEAM= \
+        SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
+        EXCLUDED_ARCHS=x86_64
+    products={{ quote(derived_data_path) }}/Build/Products
+    brewy_app=$(find "${products}" -name 'Brewy.app' -type d -print -quit)
+    ui_test_bundle=$(find "${products}" -name 'BrewyUITests.xctest' -type d -print -quit)
+    runner_app=$(find "${products}" -name 'BrewyUITests-Runner.app' -type d -print -quit)
+    test -n "${brewy_app}"
+    test -n "${ui_test_bundle}"
+    test -n "${runner_app}"
+    codesign --verify --deep --strict --verbose=2 "${brewy_app}"
+    codesign --verify --strict --verbose=2 "${ui_test_bundle}"
+    codesign --verify --deep --strict --verbose=2 "${runner_app}"
+
+# Validate release-note formatting and appcast rendering
+release-helpers:
+    python3 scripts/validate-release-helpers.py
+
+# Exercise path routing with control characters and unknown names
+ci-routing:
+    bash scripts/ci-path-routing.sh --self-test
+
 # Lint
 
 # fleet:block audit
@@ -124,6 +160,8 @@ check:
     else
         skip lychee lychee lychee
     fi
+    run bash scripts/ci-path-routing.sh --self-test
+    run python3 scripts/validate-release-helpers.py
     run bash scripts/brew-json-probe/build.sh /private/tmp/brewy-brew-json-probe
     run xcodebuild test \
         -project Brewy.xcodeproj \

--- a/scripts/ci-path-routing.sh
+++ b/scripts/ci-path-routing.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+reset_ci_routes() {
+  NEEDS_LINT=0
+  NEEDS_TESTS=0
+  NEEDS_PROBE=0
+  NEEDS_PERIPHERY=0
+  NEEDS_RELEASE_HELPERS=0
+  RUN_CODEQL=false
+  RUN_ZIZMOR=false
+}
+
+select_all_ci_routes() {
+  NEEDS_LINT=1
+  NEEDS_TESTS=1
+  NEEDS_PROBE=1
+  NEEDS_PERIPHERY=1
+  NEEDS_RELEASE_HELPERS=1
+  RUN_CODEQL=true
+  RUN_ZIZMOR=true
+}
+
+route_ci_path() {
+  local path="$1"
+  local routed=0
+
+  if [[ "${path}" == *.swift || "${path}" == Brewy/* || "${path}" == BrewyTests/* ||
+        "${path}" == BrewyUITests/* || "${path}" == Brewy.xcodeproj/* ||
+        "${path}" == .swiftlint.yml || "${path}" == .github/workflows/ci.yml ]]; then
+    NEEDS_LINT=1
+    NEEDS_TESTS=1
+    routed=1
+  fi
+
+  if [[ "${path}" == *.md || "${path}" == _typos.toml ]]; then
+    NEEDS_LINT=1
+    routed=1
+  fi
+
+  if [[ "${path}" == .github/workflows/release.yml ||
+        "${path}" == .github/format-release-notes.py ||
+        "${path}" == .github/appcast-template.xml ||
+        "${path}" == scripts/validate-release-helpers.py ]]; then
+    NEEDS_LINT=1
+    NEEDS_RELEASE_HELPERS=1
+    routed=1
+  fi
+
+  if [[ "${path}" == Brewy/Models/* || "${path}" == scripts/brew-json-probe/* ||
+        "${path}" == .github/workflows/brew-json-probe.yml ||
+        "${path}" == .github/workflows/ci.yml ]]; then
+    NEEDS_PROBE=1
+    routed=1
+  fi
+
+  if [[ "${path}" == *.swift || "${path}" == Brewy/* || "${path}" == BrewyTests/* ||
+        "${path}" == BrewyUITests/* || "${path}" == Brewy.xcodeproj/* ||
+        "${path}" == .periphery.yml || "${path}" == .github/workflows/ci.yml ]]; then
+    NEEDS_PERIPHERY=1
+    routed=1
+  fi
+
+  if [[ "${path}" == Brewy/* || "${path}" == BrewyTests/* || "${path}" == BrewyUITests/* ]]; then
+    RUN_CODEQL=true
+    routed=1
+  fi
+
+  if [[ "${path}" == .github/workflows/* ]]; then
+    RUN_ZIZMOR=true
+    routed=1
+  fi
+
+  if [[ "${path}" == assets/* || "${path}" == .github/* || "${path}" == scripts/* ||
+        "${path}" == .githooks/* || "${path}" == .* || "${path}" == LICENSE ||
+        "${path}" == justfile ]]; then
+    NEEDS_LINT=1
+    routed=1
+  fi
+
+  if [[ "${routed}" -eq 0 ]]; then
+    select_all_ci_routes
+  fi
+}
+
+assert_source_path_routes() {
+  reset_ci_routes
+  route_ci_path "$1"
+  [[ "${NEEDS_LINT}" -eq 1 ]]
+  [[ "${NEEDS_TESTS}" -eq 1 ]]
+  [[ "${NEEDS_PERIPHERY}" -eq 1 ]]
+  [[ "${RUN_CODEQL}" == true ]]
+}
+
+validate_ci_path_routing() {
+  local source_paths=(
+    $'Brewy/quoted\tinput.swift'
+    $'Brewy/newline\ninput.swift'
+    'Brewy/double"quote.swift'
+    'Brewy/back\slash.swift'
+    'Brewy/non-ASCII-café.swift'
+    'Brewy/space name.swift'
+    'Brewy/Info.plist'
+    'Brewy/Brewy.entitlements'
+    'Brewy/Assets.xcassets/AppIcon.appiconset/Contents.json'
+    'BrewyTests/Fixtures/appcast.xml'
+    'BrewyUITests/Fixtures/screenshot.png'
+  )
+  local path
+  for path in "${source_paths[@]}"; do
+    assert_source_path_routes "${path}"
+  done
+
+  reset_ci_routes
+  route_ci_path '-leading-dash'
+  [[ "${NEEDS_LINT}" -eq 1 ]]
+  [[ "${NEEDS_TESTS}" -eq 1 ]]
+  [[ "${NEEDS_PROBE}" -eq 1 ]]
+  [[ "${NEEDS_PERIPHERY}" -eq 1 ]]
+  [[ "${NEEDS_RELEASE_HELPERS}" -eq 1 ]]
+  [[ "${RUN_CODEQL}" == true ]]
+  [[ "${RUN_ZIZMOR}" == true ]]
+
+  reset_ci_routes
+  route_ci_path 'README.md'
+  [[ "${NEEDS_LINT}" -eq 1 ]]
+  [[ "${NEEDS_TESTS}" -eq 0 ]]
+  [[ "${RUN_CODEQL}" == false ]]
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
+  if [[ "${1:-}" != "--self-test" ]]; then
+    echo "usage: $0 --self-test" >&2
+    exit 2
+  fi
+  validate_ci_path_routing
+  echo "CI path routing validation passed."
+fi

--- a/scripts/validate-release-helpers.py
+++ b/scripts/validate-release-helpers.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Exercise release-note formatting and appcast rendering without publishing."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from string import Template
+import sys
+import xml.etree.ElementTree as ET
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FORMATTER_PATH = ROOT / ".github" / "format-release-notes.py"
+APPCAST_PATH = ROOT / ".github" / "appcast-template.xml"
+SPARKLE_NAMESPACE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+
+
+def load_formatter():
+    sys.dont_write_bytecode = True
+    spec = importlib.util.spec_from_file_location("format_release_notes", FORMATTER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load the release-note formatter")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def validate_release_notes() -> str:
+    formatter = load_formatter()
+    raw_notes = """## What's Changed
+* feat(ui): render <trusted> & ]]> <evil> state by @contributor in https://github.com/starhaven-io/Brewy/pull/1
+* fix: preserve an apostrophe's meaning by @contributor in https://github.com/starhaven-io/Brewy/pull/2
+* ci: internal-only change by @contributor in https://github.com/starhaven-io/Brewy/pull/3
+* uncategorized improvement by @contributor in https://github.com/starhaven-io/Brewy/pull/4
+**Full Changelog**: https://github.com/starhaven-io/Brewy/compare/0.1.0...0.2.0
+"""
+    sections, changelog_url = formatter.parse_notes(raw_notes)
+    assert sections == {
+        "What's New": ["render <trusted> & ]]> <evil> state"],
+        "Fixes": ["preserve an apostrophe's meaning"],
+        "Other": ["uncategorized improvement"],
+    }
+    assert changelog_url == "https://github.com/starhaven-io/Brewy/compare/0.1.0...0.2.0"
+
+    markdown = formatter.format_markdown("0.2.0", sections, changelog_url)
+    assert "internal-only change" not in markdown
+    assert "## Brewy 0.2.0" in markdown
+
+    rendered_html = formatter.format_html("0.2.0", sections, changelog_url)
+    assert "&lt;trusted&gt; &amp; ]]&gt; &lt;evil&gt; state" in rendered_html
+    assert "<trusted>" not in rendered_html
+    assert "]]>" not in rendered_html
+    return rendered_html
+
+
+def validate_appcast(release_notes_html: str) -> None:
+    values = {
+        "TAG": "0.2.0",
+        "PUBDATE": "Wed, 02 Sep 2026 20:00:00 +0000",
+        "BUILD_NUMBER": "42",
+        "DOWNLOAD_URL": "https://github.com/starhaven-io/Brewy/releases/download/0.2.0/Brewy-0.2.0.zip",
+        "SPARKLE_LENGTH": "123456",
+        "SPARKLE_SIG": "base64-signature",
+        "RELEASE_NOTES_HTML": release_notes_html,
+    }
+    rendered = Template(APPCAST_PATH.read_text(encoding="utf-8")).substitute(values)
+    root = ET.fromstring(rendered)
+    item = root.find("./channel/item")
+    assert item is not None
+    assert item.findtext("title") == values["TAG"]
+    assert item.findtext(f"{{{SPARKLE_NAMESPACE}}}version") == values["BUILD_NUMBER"]
+    assert item.find("evil") is None
+    enclosure = item.find("enclosure")
+    assert enclosure is not None
+    assert enclosure.get("url") == values["DOWNLOAD_URL"]
+    assert enclosure.get("length") == values["SPARKLE_LENGTH"]
+    assert enclosure.get(f"{{{SPARKLE_NAMESPACE}}}edSignature") == values["SPARKLE_SIG"]
+
+
+def main() -> None:
+    release_notes_html = validate_release_notes()
+    validate_appcast(release_notes_html)
+    print("Release helper validation passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Brewy trusted a Brewfile by path and digest but still handed Homebrew the path, so a file replaced between the check and the launch ran as trusted. `brew bundle list` and `check` now receive the approved bytes over standard input, trust rereads and digest-checks the file on every use, symbolic links must resolve to a regular file no larger than 1 MB, and `bundle dump` writes through a private generated file with Homebrew auto-update suppressed so update output cannot land in the Brewfile. History entries that consume a Brewfile are no longer retryable, and a failed dump retries through the same path.

The release workflow checks out the dispatch commit in every job, requires any existing tag to resolve to it, resumes only a draft that targets it, refuses to replace a published asset, and generates notes and the appcast from that revision. CI derives its matrix from a routing helper read from the base revision rather than the pull request, consumes NUL-delimited paths so control characters cannot slip past anchored routes, fails closed when the helper is missing or the diff fails, and the aggregate job requires every leg the generator requested instead of accepting skips. UI tests run in their own ad hoc-signed leg whose signatures and test count are verified.

Release notes loading is bounded at the network, parser, and sanitizer layers: the feed is capped at 1 MB, entity declarations abort parsing, per-field limits apply, HTML is reduced to an allowlist of tags with only validated http and https links, and conversion stays on the main actor. The sudo path for services is removed, service loading distinguishes a Homebrew failure from an empty list, dependency references carry their source so formulae and casks that share a name no longer collide in trees, groups, and navigation, history and group saves are synchronous so writes cannot reorder, and the package cache schema moves to version 2.

AI disclosure: Daybreak Blue and Claude Fable 5.1 with manual testing and review.
