### PR TITLE
ci: drop the periphery dead-code scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
           # PR coverage comparisons.
           if [[ "${EVENT_NAME}" == "push" ]]; then
             add_check '{"name":"Lint","check":"lint","runner":"macos-26"}'
-            add_check '{"name":"Periphery","check":"periphery","runner":"macos-26"}'
             add_check '{"name":"Build Brew JSON Probe","check":"probe-build","runner":"macos-26"}'
             add_check '{"name":"Test (Thread Sanitizer)","check":"test-tsan","runner":"macos-26","xcodebuild_flags":"-only-testing:BrewyTests -enableCodeCoverage YES -enableThreadSanitizer YES","result_bundle":"TestResults-TSAN","environment":"codecov"}'
             add_check '{"name":"Test (signed UI runner)","check":"test-ui","runner":"macos-26","xcodebuild_flags":"-only-testing:BrewyUITests","result_bundle":"TestResults-UI"}'
@@ -88,7 +87,6 @@ jobs:
             NEEDS_LINT=1
             NEEDS_TESTS=1
             NEEDS_PROBE=1
-            NEEDS_PERIPHERY=1
             NEEDS_RELEASE_HELPERS=1
             RUN_CODEQL=true
             RUN_ZIZMOR=true
@@ -126,10 +124,6 @@ jobs:
 
           if [[ "${NEEDS_PROBE}" -eq 1 ]]; then
             add_check '{"name":"Build Brew JSON Probe","check":"probe-build","runner":"macos-26"}'
-          fi
-
-          if [[ "${NEEDS_PERIPHERY}" -eq 1 ]]; then
-            add_check '{"name":"Periphery","check":"periphery","runner":"macos-26"}'
           fi
 
           if [[ "${NEEDS_RELEASE_HELPERS}" -eq 1 ]]; then
@@ -184,7 +178,7 @@ jobs:
 
       - name: Restore Homebrew downloads
         id: homebrew-cache
-        if: matrix.check == 'lint' || matrix.check == 'periphery'
+        if: matrix.check == 'lint'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/Library/Caches/Homebrew
@@ -221,32 +215,6 @@ jobs:
       - name: Validate CI path routing
         if: matrix.check == 'lint'
         run: bash scripts/ci-path-routing.sh --self-test
-
-      - name: Install Periphery
-        if: matrix.check == 'periphery'
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: 1
-          HOMEBREW_NO_ENV_HINTS: 1
-        run: brew install periphery
-
-      - name: Save Periphery Homebrew downloads
-        if: >
-          github.event_name == 'push' &&
-          matrix.check == 'periphery' &&
-          steps.homebrew-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/Library/Caches/Homebrew
-          key: ${{ steps.homebrew-cache.outputs.cache-primary-key }}
-
-      - name: Periphery
-        if: matrix.check == 'periphery'
-        # --no-superfluous-ignore-comments: CI's toolchain resolves the SwiftUI $-binding refs the
-        # local one misses, so it would otherwise flag the periphery:ignore comments as redundant.
-        run: |
-          periphery scan --strict --disable-update-check --no-superfluous-ignore-comments \
-            -- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO EXCLUDED_ARCHS=x86_64
-
 
       - name: Build (Release)
         if: matrix.check == 'build-release'

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,3 +1,0 @@
-project: Brewy.xcodeproj
-schemes:
-- Brewy

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -37,7 +37,6 @@ struct ContentView: View {
     @State private var selectedGroupItem: PackageGroup?
     @State private var selectedHistoryEntry: ActionHistoryEntry?
     @State private var servicesRefreshTrigger = 0
-    // periphery:ignore - Mutated through PackageListView's search binding.
     @State private var searchText = ""
     @State private var showWhatsNew = false
     @State private var showCleanupConfirm = false

--- a/Brewy/Views/DependencyTreeView.swift
+++ b/Brewy/Views/DependencyTreeView.swift
@@ -5,9 +5,7 @@ struct DependencyTreeSection: View {
     private var brewService
     let package: BrewPackage
 
-    // periphery:ignore - Read and written through DisclosureGroup's projected binding.
     @State private var pulledInExpanded = false
-    // periphery:ignore - Read and written through DisclosureGroup's projected binding.
     @State private var pullsInExpanded = false
 
     var body: some View {

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -6,7 +6,6 @@ struct PackageDetailView: View {
     let package: BrewPackage
     @State private var detailedInfo: String = ""
     @State private var isLoadingInfo = false
-    // periphery:ignore - Read and written through ActionBar and confirmationDialog bindings.
     @State private var showUninstallConfirm = false
     @State private var enrichedPackage: BrewPackage?
 

--- a/Brewy/Views/PackageListView.swift
+++ b/Brewy/Views/PackageListView.swift
@@ -13,7 +13,6 @@ struct PackageListView: View {
     @Binding var searchText: String
     @State private var searchScope: SearchScope = .installed
     @State private var searchTask: Task<Void, Never>?
-    // periphery:ignore - Read and written through toolbar and row-selection bindings.
     @State private var selectedForUpgrade: Set<String> = []
     @State private var isSelectingForUpgrade = false
 

--- a/Brewy/Views/SharedViews.swift
+++ b/Brewy/Views/SharedViews.swift
@@ -13,7 +13,6 @@ extension FocusedValues {
 
 struct ColumnSearchBar<Accessory: View>: View {
     @Binding private var text: String
-    // periphery:ignore - Read through NSViewRepresentable and focused-scene projected bindings.
     @State private var isSearchFocused = false
     private let prompt: String
     private let accessibilityIdentifier: String

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thanks for helping improve Brewy. This document covers the local setup, verifica
 Optional tooling used by the full local gate:
 
 ```sh
-brew install swiftlint typos-cli zizmor periphery lychee
+brew install swiftlint typos-cli zizmor lychee
 ```
 
 ## Getting started
@@ -36,7 +36,6 @@ just lint        # SwiftLint (--strict)
 just typos       # spell-check
 just test        # unit tests (BrewyTests; UI tests need code signing)
 just test-ui     # UI tests with an ad hoc-signed test runner
-just periphery   # unused-code scan
 just audit       # GitHub Actions audit (zizmor)
 just lychee      # README and CONTRIBUTING link check
 just check       # full static and unit-test gate
@@ -44,7 +43,7 @@ just check       # full static and unit-test gate
 
 Once you've run `just install-hooks`, the pre-push hook runs `just check` automatically on `git push`.
 
-CI builds with `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES`, runs SwiftLint in `--strict` mode, audits workflows when they change, scans for unused code, exercises unit tests under sanitizer configurations, and runs UI tests with an ad hoc-signed runner. Warnings and lint violations fail the build, so a clean `just check` locally is the best way to avoid CI surprises.
+CI builds with `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES`, runs SwiftLint in `--strict` mode, audits workflows when they change, exercises unit tests under sanitizer configurations, and runs UI tests with an ad hoc-signed runner. Warnings and lint violations fail the build, so a clean `just check` locally is the best way to avoid CI surprises.
 
 Run `just lychee` after changing links in README or CONTRIBUTING.
 

--- a/justfile
+++ b/justfile
@@ -107,10 +107,6 @@ lint:
 typos:
     typos
 
-# Scan for unused code (uses .periphery.yml)
-periphery:
-    periphery scan --clean-build
-
 # Check README and CONTRIBUTING links
 lychee:
     lychee --config lychee.toml README.md CONTRIBUTING.md
@@ -147,13 +143,6 @@ check:
         run zizmor --persona auditor .github/workflows/
     else
         skip audit zizmor zizmor
-    fi
-    if command -v periphery &>/dev/null; then
-        # Match CI: tolerate periphery:ignore comments CI sees as redundant (SwiftUI $-binding refs).
-        run periphery scan --strict --disable-update-check --no-superfluous-ignore-comments --clean-build \
-            -- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO EXCLUDED_ARCHS=x86_64
-    else
-        skip periphery periphery periphery
     fi
     if command -v lychee &>/dev/null; then
         run lychee --config lychee.toml README.md CONTRIBUTING.md

--- a/scripts/ci-path-routing.sh
+++ b/scripts/ci-path-routing.sh
@@ -4,7 +4,6 @@ reset_ci_routes() {
   NEEDS_LINT=0
   NEEDS_TESTS=0
   NEEDS_PROBE=0
-  NEEDS_PERIPHERY=0
   NEEDS_RELEASE_HELPERS=0
   RUN_CODEQL=false
   RUN_ZIZMOR=false
@@ -14,7 +13,6 @@ select_all_ci_routes() {
   NEEDS_LINT=1
   NEEDS_TESTS=1
   NEEDS_PROBE=1
-  NEEDS_PERIPHERY=1
   NEEDS_RELEASE_HELPERS=1
   RUN_CODEQL=true
   RUN_ZIZMOR=true
@@ -53,13 +51,6 @@ route_ci_path() {
     routed=1
   fi
 
-  if [[ "${path}" == *.swift || "${path}" == Brewy/* || "${path}" == BrewyTests/* ||
-        "${path}" == BrewyUITests/* || "${path}" == Brewy.xcodeproj/* ||
-        "${path}" == .periphery.yml || "${path}" == .github/workflows/ci.yml ]]; then
-    NEEDS_PERIPHERY=1
-    routed=1
-  fi
-
   if [[ "${path}" == Brewy/* || "${path}" == BrewyTests/* || "${path}" == BrewyUITests/* ]]; then
     RUN_CODEQL=true
     routed=1
@@ -87,7 +78,6 @@ assert_source_path_routes() {
   route_ci_path "$1"
   [[ "${NEEDS_LINT}" -eq 1 ]]
   [[ "${NEEDS_TESTS}" -eq 1 ]]
-  [[ "${NEEDS_PERIPHERY}" -eq 1 ]]
   [[ "${RUN_CODEQL}" == true ]]
 }
 
@@ -115,7 +105,6 @@ validate_ci_path_routing() {
   [[ "${NEEDS_LINT}" -eq 1 ]]
   [[ "${NEEDS_TESTS}" -eq 1 ]]
   [[ "${NEEDS_PROBE}" -eq 1 ]]
-  [[ "${NEEDS_PERIPHERY}" -eq 1 ]]
   [[ "${NEEDS_RELEASE_HELPERS}" -eq 1 ]]
   [[ "${RUN_CODEQL}" == true ]]
   [[ "${RUN_ZIZMOR}" == true ]]


### PR DESCRIPTION
Periphery has gone closed source, so this drops the dead-code scan: the CI leg and its Homebrew cache, the just recipe and check step, the config file, and the periphery:ignore comments on SwiftUI state.

The path router drops its Periphery route. The remaining routes and the fail-closed fallbacks are unchanged.

AI disclosure: Claude Fable 5.1 with manual testing and review.
