### PR TITLE
ci: gate the conclusion aggregate on the pinprick audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,9 +434,21 @@ jobs:
       security-events: write # required for zizmor SARIF upload
     uses: starhaven-io/.github/.github/workflows/reusable-zizmor.yml@e748ec16bd1207114a766d1d761a6743a6e3bf3a # v2026.09.09.4
 
+  pinprick:
+    name: pinprick
+    needs: generate-matrix
+    if: needs.generate-matrix.outputs.run_zizmor == 'true'
+    permissions:
+      contents: read
+      security-events: write # required for pinprick SARIF upload
+    uses: starhaven-io/.github/.github/workflows/reusable-pinprick-audit.yml@e748ec16bd1207114a766d1d761a6743a6e3bf3a # v2026.09.09.4
+    with:
+      advanced-security: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      fail-on-findings: true
+
   conclusion:
     name: conclusion
-    needs: [generate-matrix, commits, check, codeql, zizmor, codecov]
+    needs: [generate-matrix, commits, check, codeql, zizmor, pinprick, codecov]
     runs-on: ubuntu-slim
     timeout-minutes: 15
     if: always()
@@ -450,35 +462,42 @@ jobs:
           CHECK_RESULT: ${{ needs.check.result }}
           CODEQL_RESULT: ${{ needs.codeql.result }}
           ZIZMOR_RESULT: ${{ needs.zizmor.result }}
+          PINPRICK_RESULT: ${{ needs.pinprick.result }}
           GENERATOR_RESULT: ${{ needs.generate-matrix.result }}
           MATRIX: ${{ needs.generate-matrix.outputs.matrix }}
           RUN_CODEQL: ${{ needs.generate-matrix.outputs.run_codeql }}
           RUN_ZIZMOR: ${{ needs.generate-matrix.outputs.run_zizmor }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
+          require_result() {
+            local name="$1" result="$2" required="$3"
+            case "${required}" in
+              true) test "${result}" = success ;;
+              false) test "${result}" = skipped ;;
+              *) echo "::error::Invalid routing decision for ${name}."; return 1 ;;
+            esac || { echo "::error::${name} ended with ${result:-no result}."; return 1; }
+          }
+
           test "${GENERATOR_RESULT}" = "success"
-          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
-            test "${COMMITS_RESULT}" = "success"
-          else
-            test "${COMMITS_RESULT}" = "skipped"
-          fi
+          case "${EVENT_NAME}" in
+            pull_request) require_result commits "${COMMITS_RESULT}" true ;;
+            push) require_result commits "${COMMITS_RESULT}" false ;;
+            *) echo "::error::Unexpected CI event."; exit 1 ;;
+          esac
           if [[ "${MATRIX}" == "[]" ]]; then
-            test "${CHECK_RESULT}" = "skipped"
+            require_result check "${CHECK_RESULT}" false
+          elif [[ -n "${MATRIX}" ]]; then
+            require_result check "${CHECK_RESULT}" true
           else
-            test "${CHECK_RESULT}" = "success"
+            echo "::error::The check matrix could not be determined."
+            exit 1
           fi
-          if [[ "${RUN_CODEQL}" == "true" ]]; then
-            test "${CODEQL_RESULT}" = "success"
-          else
-            test "${CODEQL_RESULT}" = "skipped"
-          fi
-          if [[ "${RUN_ZIZMOR}" == "true" ]]; then
-            test "${ZIZMOR_RESULT}" = "success"
-          else
-            test "${ZIZMOR_RESULT}" = "skipped"
-          fi
-          if [[ "${RUN_CODECOV}" == "true" && "${CODECOV_ELIGIBLE}" == "true" ]]; then
-            test "${CODECOV_RESULT}" = "success"
-          else
-            test "${CODECOV_RESULT}" = "skipped"
-          fi
+          require_result codeql "${CODEQL_RESULT}" "${RUN_CODEQL}"
+          require_result zizmor "${ZIZMOR_RESULT}" "${RUN_ZIZMOR}"
+          require_result pinprick "${PINPRICK_RESULT}" "${RUN_ZIZMOR}"
+          case "${RUN_CODECOV}:${CODECOV_ELIGIBLE}" in
+            true:true) CODECOV_REQUIRED=true ;;
+            true:false | false:true | false:false) CODECOV_REQUIRED=false ;;
+            *) echo "::error::Invalid Codecov routing decision."; exit 1 ;;
+          esac
+          require_result codecov "${CODECOV_RESULT}" "${CODECOV_REQUIRED}"

--- a/scripts/tests/test_ci_conclusion.py
+++ b/scripts/tests/test_ci_conclusion.py
@@ -1,0 +1,82 @@
+import os
+from pathlib import Path
+import re
+import subprocess
+import textwrap
+import unittest
+
+
+WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "ci.yml"
+
+
+def workflow_run_block(step_name: str) -> str:
+    source = WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^      - name: {re.escape(step_name)}\n(?:^        .*\n)*?^        run: \|\n(?P<run>(?:^          .*\n|^\n)+)",
+        source,
+        re.MULTILINE,
+    )
+    if match is None:
+        raise AssertionError(f"missing workflow step: {step_name}")
+    return textwrap.dedent(match.group("run"))
+
+
+class CIConclusionTests(unittest.TestCase):
+    def setUp(self):
+        self.script = workflow_run_block("Result")
+        self.environment = {
+            "GITHUB_EVENT_NAME": "pull_request",
+            "GENERATOR_RESULT": "success",
+            "COMMITS_RESULT": "success",
+            "CHECK_RESULT": "success",
+            "CODEQL_RESULT": "success",
+            "ZIZMOR_RESULT": "success",
+            "PINPRICK_RESULT": "success",
+            "CODECOV_RESULT": "success",
+            "MATRIX": '[{"check":"test"}]',
+            "RUN_CODEQL": "true",
+            "RUN_ZIZMOR": "true",
+            "RUN_CODECOV": "true",
+            "CODECOV_ELIGIBLE": "true",
+            "EVENT_NAME": "pull_request",
+        }
+
+    def conclude(self, **overrides):
+        return subprocess.run(
+            ["/bin/bash", "-euo", "pipefail", "-c", self.script],
+            env={**os.environ, **self.environment, **overrides},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_required_audit_results_fail_closed(self):
+        self.assertEqual(self.conclude().returncode, 0)
+        for result in ("failure", "cancelled", "skipped", ""):
+            with self.subTest(result=result):
+                self.assertNotEqual(self.conclude(PINPRICK_RESULT=result).returncode, 0)
+
+    def test_only_unselected_workflow_audits_may_skip(self):
+        self.assertEqual(
+            self.conclude(RUN_ZIZMOR="false", ZIZMOR_RESULT="skipped", PINPRICK_RESULT="skipped").returncode,
+            0,
+        )
+        self.assertNotEqual(
+            self.conclude(RUN_ZIZMOR="false", ZIZMOR_RESULT="skipped", PINPRICK_RESULT="failure").returncode,
+            0,
+        )
+        self.assertNotEqual(
+            self.conclude(RUN_ZIZMOR="", ZIZMOR_RESULT="skipped", PINPRICK_RESULT="skipped").returncode,
+            0,
+        )
+
+    def test_every_routing_decision_fails_closed(self):
+        self.assertNotEqual(self.conclude(EVENT_NAME="unknown", COMMITS_RESULT="skipped").returncode, 0)
+        self.assertNotEqual(self.conclude(MATRIX="", CHECK_RESULT="skipped").returncode, 0)
+        self.assertNotEqual(self.conclude(RUN_CODEQL="", CODEQL_RESULT="skipped").returncode, 0)
+        self.assertNotEqual(self.conclude(RUN_CODECOV="", CODECOV_RESULT="skipped").returncode, 0)
+        self.assertNotEqual(self.conclude(CODECOV_ELIGIBLE="", CODECOV_RESULT="skipped").returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The aggregate did not depend on an audit job, so a failing security audit could not block a merge. This adds the inline audit to the dependency graph, makes the matrix, audit and Codecov routing fail closed on an unknown decision, and covers the outcomes with a truth table.

Part of the fleet conclusion contract: starhaven-io/.github#188 declared it, starhaven-io/.github#189 made it deliverable. The added audit call is pinned at the delivered fleet release v2026.09.09.4; a new call is admitted at the canonical pin, which is what Brewy #355 initially failed on.

AI disclosure: Claude Opus 5 with the full `just check` gate run locally on this commit.